### PR TITLE
chore: Backport of marktext#2436

### DIFF
--- a/lib/config/index.js
+++ b/lib/config/index.js
@@ -245,8 +245,9 @@ export const PREVIEW_DOMPURIFY_CONFIG = {
     html: true,
     svg: true,
     svgFilters: true,
-    mathMl: true
-  }
+    mathMl: false
+  },
+  RETURN_TRUSTED_TYPE: false
 }
 export const DEFAULT_SEARCH_OPTIONS = {
   isCaseSensitive: false,

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "webpack serve --config ./example/webpack.config.js --open",
     "build": "NODE_ENV=production webpack --config ./scripts/webpack.config.js",
     "test": "jest --env=jsdom",
+    "lint": "eslint lib",
     "lint:fix": "eslint --fix lib",
     "postinstall": "husky install",
     "prepublishOnly": "pinst --disable",


### PR DESCRIPTION
> Disable MathML due to DOMPurify security issues.

Backport of https://github.com/marktext/marktext/pull/2436