### PR TITLE
docs: add missing `init()` call in example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ import Muya from '@marktext/muya'
 
 const container = document.querySelector('#editor')
 const muya = new Muya(container)
+muya.init();
 ```
 
 ## Documents


### PR DESCRIPTION
If `init()` is not called, the editor will not function correctly.

Fixes #145 .