### PR TITLE
fix: imagetoolbar icon style

### DIFF
--- a/packages/ui/imageToolbar/index.css
+++ b/packages/ui/imageToolbar/index.css
@@ -88,7 +88,7 @@
   display: inline-block;
   width: 100%;
   height: 100%;
-  overflow: auto;
+  overflow: hidden;
 
   color: var(--icon-color);
 


### PR DESCRIPTION
before
![image](https://github.com/marktext/muya/assets/31177490/ddad5b74-4d1f-4681-b992-420acdaccac7)

after
![image](https://github.com/marktext/muya/assets/31177490/6da225b9-b771-4dbb-be71-5eda8542880e)
