### PR TITLE
fix: avoid shared Marked state leaking across renderHtml calls

### DIFF
--- a/packages/core/src/utils/marked/getClipboardHtml.ts
+++ b/packages/core/src/utils/marked/getClipboardHtml.ts
@@ -1,5 +1,5 @@
 import type { ILexOption } from './types';
-import { marked } from 'marked';
+import { Marked } from 'marked';
 import mathExtension from './extensions/math';
 import superSubScriptExtension from './extensions/superSubscript';
 import fm, { frontMatterRender } from './frontMatter';
@@ -11,6 +11,12 @@ export function getClipBoardHtml(src: string, options: ILexOption = {}) {
     const { frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
         = options;
     let html = '';
+
+    // Use a fresh Marked instance per call to avoid polluting the global
+    // `marked` singleton — `.use({ walkTokens })` chains rather than replaces,
+    // and the global is shared with anything else in the bundle that imports
+    // `marked`.
+    const marked = new Marked();
 
     marked.use({
         walkTokens: walkTokens({ math, isGitlabCompatibilityEnabled }),
@@ -36,7 +42,7 @@ export function getClipBoardHtml(src: string, options: ILexOption = {}) {
         }
     }
 
-    html += marked(src);
+    html += marked.parse(src);
 
     return html;
 }

--- a/packages/core/src/utils/marked/getHighlightHtml.ts
+++ b/packages/core/src/utils/marked/getHighlightHtml.ts
@@ -15,32 +15,32 @@ const DIAGRAM_TYPE = [
     'vega-lite',
 ];
 
-const marked = new Marked(
-    markedHighlight({
-        highlight(code, lang) {
-            // Language may be undefined (GH#591)
-            if (!lang)
-                return code;
+function highlight(code: string, lang: string) {
+    // Language may be undefined (GH#591)
+    if (!lang)
+        return code;
 
-            if (DIAGRAM_TYPE.includes(lang))
-                return code;
+    if (DIAGRAM_TYPE.includes(lang))
+        return code;
 
-            const grammar = Prism.languages[lang];
-            if (!grammar) {
-                console.warn(`Unable to find grammar for "${lang}".`);
-                return code;
-            }
-            return Prism.highlight(code, grammar, lang);
-        },
-    }),
-);
+    const grammar = Prism.languages[lang];
+    if (!grammar) {
+        console.warn(`Unable to find grammar for "${lang}".`);
+        return code;
+    }
+    return Prism.highlight(code, grammar, lang);
+}
 
 export function getHighlightHtml(src: string, options: ILexOption = {}) {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
     const { frontMatter, math, isGitlabCompatibilityEnabled, superSubScript }
         = options;
 
-    let html = '';
+    // Build a fresh Marked instance per call. `Marked.use({ walkTokens })`
+    // chains rather than replaces, so reusing a module-level singleton would
+    // cause walkTokens to fire N times after N invocations and corrupt token
+    // state (e.g. wiping `lang` on subsequent runs).
+    const marked = new Marked(markedHighlight({ highlight }));
 
     marked.use({
         walkTokens: walkTokens({ math, isGitlabCompatibilityEnabled }),
@@ -59,6 +59,8 @@ export function getHighlightHtml(src: string, options: ILexOption = {}) {
 
     if (superSubScript)
         marked.use(superSubScriptExtension());
+
+    let html = '';
 
     if (frontMatter) {
         const { token, src: newSrc } = fm(src);

--- a/packages/core/src/utils/marked/walkTokens.ts
+++ b/packages/core/src/utils/marked/walkTokens.ts
@@ -22,9 +22,13 @@ function walkTokens(options: ILexOption) {
         }
 
         if (token.type === 'code') {
-            if (token.codeBlockStyle)
+            // Only strip the language tag for indented code blocks — those are
+            // never fenced and can't carry a language. For fenced blocks we
+            // tag them once; subsequent visits are no-ops, so this stays
+            // idempotent even if walkTokens accidentally runs multiple times.
+            if (token.codeBlockStyle === 'indented')
                 token.lang = '';
-            else if (typeof token.lang === 'string')
+            else if (!token.codeBlockStyle && typeof token.lang === 'string')
                 token.codeBlockStyle = 'fenced';
         }
 


### PR DESCRIPTION
## Summary

- `MarkdownToHtml.renderHtml()` rendered ```mermaid blocks correctly on the first call but silently dropped to `<pre><code>SOURCE</code></pre>` on every subsequent call in the same process.
- Root cause is three reinforcing issues in the `marked` helpers:
  1. `getHighlightHtml` reused a module-level `Marked` instance and `getClipBoardHtml` reused the package-global `marked` singleton.
  2. Both called `.use({ walkTokens })` per invocation — and in marked@16, `Marked.use` **chains** `walkTokens` rather than replacing it, so the callback fires N times after N calls.
  3. The `code` branch in `walkTokens` was not idempotent: pass 1 set `codeBlockStyle = 'fenced'`, pass 2 then hit the truthy branch and wiped `lang`. The `<code>` element lost its `language-mermaid` class, so `renderMermaid()`'s `querySelectorAll('code.language-mermaid')` returned nothing.
- Fix: build a fresh `new Marked()` inside each helper (so nothing carries over between calls), and gate the `walkTokens` code branch on the current `codeBlockStyle` so multiple visits are no-ops.

## Files changed

- `packages/core/src/utils/marked/getHighlightHtml.ts` — fresh `Marked` per call; `highlight` lifted to module scope.
- `packages/core/src/utils/marked/getClipboardHtml.ts` — fresh `Marked` per call instead of polluting the global `marked` singleton; `marked(src)` → `marked.parse(src)`.
- `packages/core/src/utils/marked/walkTokens.ts` — only clear `lang` for `codeBlockStyle === 'indented'`; only tag fenced when `codeBlockStyle` is unset.

## Test plan

- [x] `pnpm lint:types` passes
- [x] `pnpm test` passes (12/12)
- [x] `pnpm check-circular` — no circular deps
- [x] `pnpm build` — produces `lib/{es,umd,cjs}` cleanly
- [ ] Manual: call `new MarkdownToHtml(md).renderHtml()` twice with a `mermaid` block and confirm both outputs contain `<div class="mermaid" data-processed="true"><svg>...`
- [ ] Manual: call `getClipBoardHtml()` twice and confirm output is stable

## Note on the failing `ci-lint` check

The `ci-lint` job is failing with `TypeError: Object.groupBy is not a function`, thrown from `eslint-flat-config-utils@3.2.0` during ESLint config loading. **This is a pre-existing failure on `master`** (the last 5 master `ci-lint` runs all fail with the same error, starting from #199) and is unrelated to this PR — the error is raised before ESLint reads any source file. `build`, `typecheck`, `test`, and `circular-dependences` all pass on this branch. A separate PR will fix the CI Node version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)