### PR TITLE
ci: bump CI Node from 20 to 22 to fix ESLint config loading

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -13,7 +13,7 @@ runs:
         - name: Setup Node.js
           uses: actions/setup-node@v4
           with:
-              node-version: 20
+              node-version: 22
               cache: pnpm
 
         - name: Install dependencies


### PR DESCRIPTION
## Summary

The `ci-lint` workflow has been failing on `master` since #199's dependency upgrade with:

```
TypeError: Object.groupBy is not a function
    at .../eslint-flat-config-utils@3.2.0/.../index.mjs:157:30
```

`eslint-flat-config-utils@3.2.0` does not declare an `engines` field but uses `Object.groupBy`, which was added in **Node 20.12 / 21+**. `actions/setup-node@v4` with `node-version: 20` resolves to the runner's pre-cached 20.x — which is older than 20.12 — so ESLint's flat-config loader crashes before reading any source file.

Bumping the CI Node to 22 (current LTS, active until 2027-04-30) fixes it cleanly: every dependency supports it, and we don't have to pin a fragile patch version.

Note: this only fixes the config-loading crash. Master still has ~57 pre-existing ESLint errors that will surface once the loader works again — those need a separate cleanup PR.

## Test plan

- [ ] After merge, confirm `ci-lint` runs to completion (success or fails on the pre-existing 57 errors, not on `Object.groupBy`)
- [ ] Confirm `build`, `typecheck`, `test`, `circular-dependences` still pass on Node 22

🤖 Generated with [Claude Code](https://claude.com/claude-code)