### PR TITLE
chore: clear 55 low-risk ESLint warnings left over from #204

### DIFF
--- a/packages/core/src/block/gfm/taskListCheckbox/index.ts
+++ b/packages/core/src/block/gfm/taskListCheckbox/index.ts
@@ -16,9 +16,9 @@ const debug = logger('tasklistCheckbox:');
 // In the Chrome browser, the input element is still preserved because in Chrome,
 // span has a cursor staggered problem.
 class TaskListCheckbox extends TreeNode {
-    private checked: boolean;
+    private _checked: boolean;
 
-    private eventIds: string[] = [];
+    private _eventIds: string[] = [];
 
     static override blockName = 'task-list-checkbox';
 
@@ -42,7 +42,7 @@ class TaskListCheckbox extends TreeNode {
     constructor(muya: Muya, { checked }: ITaskListItemMeta) {
         super(muya);
         this.tagName = isFirefox ? 'span' : 'input';
-        this.checked = checked;
+        this._checked = checked;
         this.attributes = isFirefox
             ? { contenteditable: 'false' }
             : { type: 'checkbox', contenteditable: 'false' };
@@ -69,13 +69,13 @@ class TaskListCheckbox extends TreeNode {
             event.stopPropagation();
 
             if (isFirefox) {
-                this.checked = !this.checked;
+                this._checked = !this._checked;
 
-                this.update(this.checked, 'user');
+                this.update(this._checked, 'user');
             }
             else {
                 const { checked } = event.target as HTMLInputElement;
-                this.checked = checked;
+                this._checked = checked;
                 this.update(checked, 'user');
             }
         };
@@ -84,7 +84,7 @@ class TaskListCheckbox extends TreeNode {
             eventCenter.attachDOMEvent(domNode!, 'click', clickHandler),
         ];
 
-        this.eventIds.push(...eventIds);
+        this._eventIds.push(...eventIds);
     }
 
     update = (checked: boolean, source = 'api') => {
@@ -109,7 +109,7 @@ class TaskListCheckbox extends TreeNode {
     };
 
     detachDOMEvents() {
-        for (const id of this.eventIds)
+        for (const id of this._eventIds)
             this.muya.eventCenter.detachDOMEvent(id);
     }
 

--- a/packages/core/src/block/scrollPage/index.ts
+++ b/packages/core/src/block/scrollPage/index.ts
@@ -75,7 +75,7 @@ export class ScrollPage extends Parent {
         const { eventCenter } = this.muya;
         const { domNode } = this;
 
-        eventCenter.attachDOMEvent(domNode!, 'click', this.clickHandler.bind(this));
+        eventCenter.attachDOMEvent(domNode!, 'click', this._clickHandler.bind(this));
     }
 
     updateState(state: TState[]) {
@@ -113,15 +113,15 @@ export class ScrollPage extends Parent {
 
     handleBlurFromContent(block: Content) {
         this._blurFocus.blur = block;
-        requestAnimationFrame(this.updateActiveStatus);
+        requestAnimationFrame(this._updateActiveStatus);
     }
 
     handleFocusFromContent(block: Content) {
         this._blurFocus.focus = block;
-        requestAnimationFrame(this.updateActiveStatus);
+        requestAnimationFrame(this._updateActiveStatus);
     }
 
-    private updateActiveStatus = () => {
+    private _updateActiveStatus = () => {
         const { blur, focus } = this._blurFocus;
 
         if (blur == null && focus == null)
@@ -165,7 +165,7 @@ export class ScrollPage extends Parent {
     };
 
     // Create a new paragraph if click the blank area in editor.
-    private clickHandler(event: Event) {
+    private _clickHandler(event: Event) {
         if (!isMouseEvent(event))
             return;
 

--- a/packages/core/src/inlineRenderer/renderer/image.ts
+++ b/packages/core/src/inlineRenderer/renderer/image.ts
@@ -70,7 +70,7 @@ export default function image(
     /**
      * The image is used to wrap the img element.
      * @param args
-     * @returns
+     * @returns The wrapping span VNode containing the image element.
      */
     const renderImageContainer = (...args: VNode[]) => {
         const data = {};

--- a/packages/core/src/inlineRenderer/renderer/index.ts
+++ b/packages/core/src/inlineRenderer/renderer/index.ts
@@ -76,6 +76,9 @@ const inlineSyntaxRenderer = {
 
 type InlineSyntaxRender = typeof inlineSyntaxRenderer;
 
+// Declaration-merged with the class below to expose mixin method signatures;
+// must share the class name, so the `I` prefix convention does not apply here.
+// eslint-disable-next-line ts/naming-convention
 interface Renderer extends InlineSyntaxRender {}
 
 @methodMixins(inlineSyntaxRenderer)

--- a/packages/core/src/selection/index.ts
+++ b/packages/core/src/selection/index.ts
@@ -142,7 +142,7 @@ class Selection {
         block: Format;
     } | null = null;
 
-    private selectInfo: {
+    private _selectInfo: {
         isSelect: boolean;
         selection: ICursor | null;
     } = {
@@ -151,7 +151,7 @@ class Selection {
     };
 
     constructor(public muya: Muya) {
-        this.listenSelectActions();
+        this._listenSelectActions();
     }
 
     selectAll() {
@@ -206,7 +206,7 @@ class Selection {
 
     /**
      * Return the current selection of doc or null if has no selection.
-     * @returns
+     * @returns The resolved selection mapped to anchor/focus blocks, or null when no selection exists.
      */
     getSelection(): ISelection | null {
         const selection = document.getSelection();
@@ -289,7 +289,7 @@ class Selection {
         this.focusBlock = focusBlock ?? block ?? null;
         this.focusPath = focusPath ?? path ?? [];
         // Update cursor.
-        this.setCursor();
+        this._setCursor();
 
         const {
             isCollapsed,
@@ -314,21 +314,21 @@ class Selection {
         });
     }
 
-    private listenSelectActions() {
+    private _listenSelectActions() {
         const { eventCenter, domNode } = this.muya;
 
         const handleMousedown = () => {
-            this.selectInfo = {
+            this._selectInfo = {
                 isSelect: true,
                 selection: null,
             };
         };
 
         const handleMouseupOrLeave = () => {
-            if (this.selectInfo.selection)
-                this.setSelection(this.selectInfo.selection);
+            if (this._selectInfo.selection)
+                this.setSelection(this._selectInfo.selection);
 
-            this.selectInfo = {
+            this._selectInfo = {
                 isSelect: false,
                 selection: null,
             };
@@ -339,7 +339,7 @@ class Selection {
                 return;
 
             const { type, shiftKey } = event;
-            if (type === 'mousemove' && !this.selectInfo.isSelect)
+            if (type === 'mousemove' && !this._selectInfo.isSelect)
                 return;
 
             if (type === 'click' && !shiftKey)
@@ -463,7 +463,7 @@ class Selection {
             }
 
             if (type === 'mousemove')
-                this.selectInfo.selection = newSelection;
+                this._selectInfo.selection = newSelection;
             else
                 this.setSelection(newSelection);
         };
@@ -479,7 +479,7 @@ class Selection {
             );
             this.selectedImage = null;
             if (imageWrapper)
-                return this.handleClickInlineImage(event, imageWrapper as HTMLElement);
+                return this._handleClickInlineImage(event, imageWrapper as HTMLElement);
         };
 
         const handleKeydown = (event: Event) => {
@@ -507,7 +507,7 @@ class Selection {
     }
 
     // Handle click inline image.
-    private handleClickInlineImage(event: Event, imageWrapper: HTMLElement) {
+    private _handleClickInlineImage(event: Event, imageWrapper: HTMLElement) {
         event.preventDefault();
         event.stopPropagation();
         const { eventCenter } = this.muya;
@@ -593,7 +593,7 @@ class Selection {
         }
     }
 
-    private selectRange(range: Range) {
+    private _selectRange(range: Range) {
         const selection = this.doc.getSelection();
 
         if (selection) {
@@ -602,7 +602,7 @@ class Selection {
         }
     }
 
-    private select(
+    private _select(
         startNode: Node,
         startOffset: number,
         endNode?: Node,
@@ -615,18 +615,18 @@ class Selection {
         else
             range.collapse(true);
 
-        this.selectRange(range);
+        this._selectRange(range);
 
         return range;
     }
 
-    private setFocus(focusNode: Node, focusOffset: number) {
+    private _setFocus(focusNode: Node, focusOffset: number) {
         const selection = this.doc.getSelection();
         if (selection)
             selection.extend(focusNode, focusOffset);
     }
 
-    private setCursor() {
+    private _setCursor() {
         const {
             anchor,
             focus,
@@ -663,9 +663,9 @@ class Selection {
         );
 
         // First set the anchor node and anchor offset, make it collapsed
-        this.select(anchorNode, anchorOffset);
+        this._select(anchorNode, anchorOffset);
         // Secondly, set the focus node and focus offset.
-        this.setFocus(focusNode, focusOffset);
+        this._setFocus(focusNode, focusOffset);
     }
 }
 

--- a/packages/core/src/state/htmlToMarkdown.ts
+++ b/packages/core/src/state/htmlToMarkdown.ts
@@ -62,10 +62,10 @@ function turnSoftBreakToSpan(html: string) {
 }
 
 export default class HtmlToMarkdown {
-    private options: ITurnoverOptions;
+    private _options: ITurnoverOptions;
 
     constructor(options = {}) {
-        this.options = Object.assign(
+        this._options = Object.assign(
             {},
             DEFAULT_TURNDOWN_CONFIG as ITurnoverOptions,
             options,
@@ -74,8 +74,7 @@ export default class HtmlToMarkdown {
 
     generate(html: string): string {
         // turn html to markdown
-        const { options } = this;
-        const turndownService = new TurndownService(options);
+        const turndownService = new TurndownService(this._options);
         usePluginsAddRules(turndownService);
 
         // fix #752, but I don't know why the &nbsp; vanished.

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -32,15 +32,15 @@ class JSONState {
 
     private _isGoing = false;
 
-    private state: TState[] = [];
+    private _state: TState[] = [];
 
     constructor(public muya: Muya, stateOrMarkdown: TState[] | string) {
         this.setContent(stateOrMarkdown);
     }
 
     apply(op: JSONOpList) {
-        this.state = json1.type.apply(
-            this.state as unknown as Doc,
+        this._state = json1.type.apply(
+            this._state as unknown as Doc,
             op,
         ) as unknown as TState[];
     }
@@ -53,7 +53,7 @@ class JSONState {
     }
 
     setState(state: TState[]) {
-        this.state = state;
+        this._state = state;
     }
 
     setMarkdown(markdown: string) {
@@ -65,7 +65,7 @@ class JSONState {
             math,
         } = this.muya.options;
 
-        this.state = new MarkdownToState({
+        this._state = new MarkdownToState({
             footnote,
             isGitlabCompatibilityEnabled,
             trimUnnecessaryCodeBlockEmptyLines,
@@ -121,7 +121,7 @@ class JSONState {
     }
 
     getState(): TState[] {
-        return deepClone(this.state);
+        return deepClone(this._state);
     }
 
     getMarkdown() {

--- a/packages/core/src/state/markdownToHtml.ts
+++ b/packages/core/src/state/markdownToHtml.ts
@@ -7,12 +7,12 @@ import loadRenderer from '../utils/diagram';
 import { getHighlightHtml } from '../utils/marked';
 
 export class MarkdownToHtml {
-    private exportContainer: HTMLDivElement | null = null;
+    private _exportContainer: HTMLDivElement | null = null;
 
     constructor(public markdown: string, public muya?: Muya) {}
 
     async renderMermaid() {
-        const codes = this.exportContainer!.querySelectorAll(
+        const codes = this._exportContainer!.querySelectorAll(
             'code.language-mermaid',
         );
         for (const code of codes) {
@@ -34,7 +34,7 @@ export class MarkdownToHtml {
             theme: 'default',
         });
         await mermaid.run({
-            nodes: [...this.exportContainer!.querySelectorAll('div.mermaid')],
+            nodes: [...this._exportContainer!.querySelectorAll('div.mermaid')],
         });
         if (this.muya) {
             mermaid.initialize({
@@ -47,7 +47,7 @@ export class MarkdownToHtml {
     async renderDiagram() {
         const selector
             = 'code.language-vega-lite, code.language-plantuml';
-        const codes = this.exportContainer!.querySelectorAll(selector);
+        const codes = this._exportContainer!.querySelectorAll(selector);
 
         for (const code of codes) {
             const rawCode = unescapeHTML(code.innerHTML);
@@ -99,7 +99,7 @@ export class MarkdownToHtml {
 
         html = sanitize(html, EXPORT_DOMPURIFY_CONFIG, false) as string;
 
-        const exportContainer = (this.exportContainer
+        const exportContainer = (this._exportContainer
             = document.createElement('div'));
         exportContainer.classList.add('mu-render-container');
         exportContainer.innerHTML = html;
@@ -123,7 +123,7 @@ export class MarkdownToHtml {
             return `${def}${str}`;
         });
 
-        this.exportContainer = null;
+        this._exportContainer = null;
 
         return `<article class="markdown-body">${result}</article>`;
     }

--- a/packages/core/src/state/stateToMarkdown.ts
+++ b/packages/core/src/state/stateToMarkdown.ts
@@ -42,10 +42,10 @@ export interface IExportMarkdownOptions {
 }
 
 export default class ExportMarkdown {
-    private listType: any[];
-    private isLooseParentList: boolean;
-    private listIndentation: string;
-    private listIndentationCount: number;
+    private _listType: any[];
+    private _isLooseParentList: boolean;
+    private _listIndentation: string;
+    private _listIndentationCount: number;
 
     constructor(
         {
@@ -54,21 +54,21 @@ export default class ExportMarkdown {
             listIndentation: 1,
         },
     ) {
-        this.listType = []; // 'ul' or 'ol'
+        this._listType = []; // 'ul' or 'ol'
         // helper to translate the first tight item in a nested list
-        this.isLooseParentList = true;
+        this._isLooseParentList = true;
 
         // set and validate settings
-        this.listIndentation = 'number';
+        this._listIndentation = 'number';
         if (listIndentation === 'dfm') {
-            this.listIndentation = 'dfm';
-            this.listIndentationCount = 4;
+            this._listIndentation = 'dfm';
+            this._listIndentationCount = 4;
         }
         else if (typeof listIndentation === 'number') {
-            this.listIndentationCount = Math.min(Math.max(listIndentation, 1), 4);
+            this._listIndentationCount = Math.min(Math.max(listIndentation, 1), 4);
         }
         else {
-            this.listIndentationCount = 1;
+            this._listIndentationCount = 1;
         }
     }
 
@@ -151,8 +151,8 @@ export default class ExportMarkdown {
                 case 'bullet-list':
 
                 case 'task-list': {
-                    let insertNewLine = this.isLooseParentList;
-                    this.isLooseParentList = true;
+                    let insertNewLine = this._isLooseParentList;
+                    this._isLooseParentList = true;
                     const { meta } = state;
 
                     // Start a new list without separation due changing the bullet or ordered list delimiter starts a new list.
@@ -168,24 +168,24 @@ export default class ExportMarkdown {
                     if (insertNewLine)
                         this.insertLineBreak(result, indent);
 
-                    this.listType.push(deepClone(meta));
+                    this._listType.push(deepClone(meta));
                     result.push(this.serializeList(state, indent, listIndent));
-                    this.listType.pop();
+                    this._listType.pop();
                     break;
                 }
 
                 case 'list-item':
 
                 case 'task-list-item': {
-                    const { loose } = this.listType[this.listType.length - 1];
+                    const { loose } = this._listType[this._listType.length - 1];
 
                     // helper variable to correct the first tight item in a nested list
-                    this.isLooseParentList = loose;
+                    this._isLooseParentList = loose;
                     if (loose)
                         this.insertLineBreak(result, indent);
 
                     result.push(this.serializeListItem(state, indent + listIndent));
-                    this.isLooseParentList = true;
+                    this._isLooseParentList = true;
                     break;
                 }
 
@@ -443,7 +443,7 @@ export default class ExportMarkdown {
         indent: string,
     ) {
         const result = [];
-        const listInfo = this.listType[this.listType.length - 1];
+        const listInfo = this._listType[this._listType.length - 1];
         const { marker, delimiter, start } = listInfo;
         const isUnorderedList = !!marker;
         const { children, name } = state;
@@ -456,7 +456,7 @@ export default class ExportMarkdown {
             // NOTE: GitHub and Bitbucket limit the list count to 99 but this is nowhere defined.
             //  We limit the number to 99 for Daring Fireball Markdown to prevent indentation issues.
             let n = start;
-            if ((this.listIndentation === 'dfm' && n > 99) || n > 999999999)
+            if ((this._listIndentation === 'dfm' && n > 99) || n > 999999999)
                 n = 1;
 
             listInfo.start++;
@@ -469,11 +469,11 @@ export default class ExportMarkdown {
 
         // New list indentation. We already added one space to the indentation
         let listIndent = '';
-        const { listIndentation } = this;
+        const { _listIndentation: listIndentation } = this;
         if (listIndentation === 'dfm')
             listIndent = ' '.repeat(4 - itemMarker.length);
         else if (listIndentation === 'number')
-            listIndent = ' '.repeat(this.listIndentationCount - 1);
+            listIndent = ' '.repeat(this._listIndentationCount - 1);
 
         // TODO: Indent subsequent paragraphs by one tab. - not important
         //  Problem: "convertStatesToMarkdown" use "indent" in spaces to indent elements. How should

--- a/packages/core/src/ui/codeBlockLanguageSelector/index.ts
+++ b/packages/core/src/ui/codeBlockLanguageSelector/index.ts
@@ -23,8 +23,8 @@ const defaultOptions = {
 
 export class CodeBlockLanguageSelector extends BaseScrollFloat {
     static pluginName = 'codePicker';
-    private oldVNode: VNode | null = null;
-    private block: ParagraphContent | LangInputContent | null = null;
+    private _oldVNode: VNode | null = null;
+    private _block: ParagraphContent | LangInputContent | null = null;
 
     constructor(muya: Muya, options = {}) {
         const name = 'mu-list-picker';
@@ -54,7 +54,7 @@ export class CodeBlockLanguageSelector extends BaseScrollFloat {
 
             const modes = search(lang);
             if (modes.length) {
-                this.block = block;
+                this._block = block;
                 this.show(domNode);
                 this.renderArray = modes;
                 this.activeItem = modes[0];
@@ -67,7 +67,7 @@ export class CodeBlockLanguageSelector extends BaseScrollFloat {
     }
 
     render() {
-        const { renderArray, oldVNode, scrollElement, activeItem } = this;
+        const { renderArray, _oldVNode: oldVNode, scrollElement, activeItem } = this;
         let children = (
             renderArray as {
                 name: string;
@@ -124,7 +124,7 @@ export class CodeBlockLanguageSelector extends BaseScrollFloat {
         else
             patch(scrollElement!, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     getItemElement(item: { name: string }): HTMLElement {
@@ -135,7 +135,7 @@ export class CodeBlockLanguageSelector extends BaseScrollFloat {
     }
 
     override selectItem(item: { name: string }) {
-        const { block, muya } = this;
+        const { _block: block, muya } = this;
         const { name } = item;
 
         if (!block)

--- a/packages/core/src/ui/emojiSelector/emoji.ts
+++ b/packages/core/src/ui/emojiSelector/emoji.ts
@@ -13,10 +13,10 @@ for (const emoji of emojis) {
 
 class Emoji {
     // cache key is the search text, and the value is search results by category.
-    private cache: Map<string, Record<string, EmojiType[]>> = new Map();
+    private _cache: Map<string, Record<string, EmojiType[]>> = new Map();
 
     search(text: string): Record<string, EmojiType[]> {
-        const { cache } = this;
+        const { _cache: cache } = this;
         if (cache.has(text))
             return cache.get(text)!;
 
@@ -37,7 +37,7 @@ class Emoji {
     }
 
     destroy() {
-        return this.cache.clear();
+        return this._cache.clear();
     }
 }
 

--- a/packages/core/src/ui/emojiSelector/index.ts
+++ b/packages/core/src/ui/emojiSelector/index.ts
@@ -20,8 +20,8 @@ const defaultOptions = {
 export class EmojiSelector extends BaseScrollFloat {
     static pluginName = 'emojiPicker';
     private _renderObj: Record<string, EmojiType[]> | null = null;
-    private oldVNode: VNode | null = null;
-    private emoji: Emoji = new Emoji();
+    private _oldVNode: VNode | null = null;
+    private _emoji: Emoji = new Emoji();
     public override renderArray: EmojiType[] = [];
     public override activeItem: EmojiType | null = null;
 
@@ -58,7 +58,7 @@ export class EmojiSelector extends BaseScrollFloat {
                 return this.hide();
             const text = emojiText.trim();
             if (text) {
-                this.renderObj = this.emoji.search(text);
+                this.renderObj = this._emoji.search(text);
                 const cb: any = (item: EmojiType) => {
                     if (block && block.setEmoji)
                         block.setEmoji(item.aliases[0]);
@@ -76,7 +76,7 @@ export class EmojiSelector extends BaseScrollFloat {
     }
 
     render() {
-        const { scrollElement, renderObj, activeItem, oldVNode } = this;
+        const { scrollElement, renderObj, activeItem, _oldVNode: oldVNode } = this;
         const { i18n } = this.muya;
 
         const children = Object.keys(renderObj).map((category) => {
@@ -109,7 +109,7 @@ export class EmojiSelector extends BaseScrollFloat {
         else
             patch(scrollElement!, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     getItemElement(item: EmojiType) {
@@ -120,6 +120,6 @@ export class EmojiSelector extends BaseScrollFloat {
 
     override destroy() {
         super.destroy();
-        this.emoji.destroy();
+        this._emoji.destroy();
     }
 }

--- a/packages/core/src/ui/imageResizeBar/index.ts
+++ b/packages/core/src/ui/imageResizeBar/index.ts
@@ -12,24 +12,24 @@ const BAR_HEIGHT = 50;
 
 export class ImageResizeBar {
     static pluginName = 'transformer';
-    private reference: HTMLElement | null = null;
-    private block: Format | null = null;
-    private imageInfo: {
+    private _reference: HTMLElement | null = null;
+    private _block: Format | null = null;
+    private _imageInfo: {
         token: ImageToken;
         imageId: string;
     } | null = null;
 
-    private movingAnchor: string | null = null;
-    private status: boolean = false;
-    private width: number | null = null;
-    private eventId: string[] = [];
-    private lastScrollTop: number | null = null;
-    private resizing: boolean = false;
+    private _movingAnchor: string | null = null;
+    private _status: boolean = false;
+    private _width: number | null = null;
+    private _eventId: string[] = [];
+    private _lastScrollTop: number | null = null;
+    private _resizing: boolean = false;
     // A container for storing drag strips
-    private container: HTMLDivElement;
+    private _container: HTMLDivElement;
 
     constructor(public muya: Muya) {
-        const container = (this.container = document.createElement('div'));
+        const container = (this._container = document.createElement('div'));
         container.classList.add('mu-transformer');
         document.body.appendChild(container);
 
@@ -40,27 +40,27 @@ export class ImageResizeBar {
         const { eventCenter, domNode } = this.muya;
 
         const scrollHandler = (event: Event) => {
-            if (typeof this.lastScrollTop !== 'number') {
-                this.lastScrollTop = (event.target as HTMLElement).scrollTop;
+            if (typeof this._lastScrollTop !== 'number') {
+                this._lastScrollTop = (event.target as HTMLElement).scrollTop;
 
                 return;
             }
 
             // only when scroll distance great than 50px, then hide the float box.
             if (
-                !this.resizing
-                && this.status
-                && Math.abs((event.target as HTMLElement).scrollTop - this.lastScrollTop) > 50
+                !this._resizing
+                && this._status
+                && Math.abs((event.target as HTMLElement).scrollTop - this._lastScrollTop) > 50
             ) {
                 this.hide();
             }
         };
 
         eventCenter.on('muya-transformer', ({ block, reference, imageInfo }) => {
-            this.reference = reference;
+            this._reference = reference;
             if (reference) {
-                this.block = block;
-                this.imageInfo = imageInfo;
+                this._block = block;
+                this._imageInfo = imageInfo;
                 setTimeout(() => {
                     this.render();
                 });
@@ -72,17 +72,17 @@ export class ImageResizeBar {
 
         eventCenter.attachDOMEvent(document, 'click', this.hide.bind(this));
         eventCenter.attachDOMEvent(domNode.parentElement!, 'scroll', scrollHandler);
-        eventCenter.attachDOMEvent(this.container, 'dragstart', event =>
+        eventCenter.attachDOMEvent(this._container, 'dragstart', event =>
             event.preventDefault());
         eventCenter.attachDOMEvent(document.body, 'mousedown', this.mouseDown);
     }
 
     render() {
         const { eventCenter } = this.muya;
-        if (this.status)
+        if (this._status)
             this.hide();
 
-        this.status = true;
+        this._status = true;
 
         this.createElements();
         this.update();
@@ -95,14 +95,14 @@ export class ImageResizeBar {
             bar.classList.add('bar');
             bar.classList.add(c);
             bar.setAttribute('data-position', c);
-            this.container.appendChild(bar);
+            this._container.appendChild(bar);
         });
     }
 
     update() {
-        const rect = this.reference!.getBoundingClientRect();
+        const rect = this._reference!.getBoundingClientRect();
         VERTICAL_BAR.forEach((c) => {
-            const bar: HTMLDivElement = this.container.querySelector(`.${c}`)!;
+            const bar: HTMLDivElement = this._container.querySelector(`.${c}`)!;
 
             switch (c) {
                 case 'left':
@@ -124,7 +124,7 @@ export class ImageResizeBar {
             return;
 
         const { eventCenter } = this.muya;
-        this.movingAnchor = target.getAttribute('data-position');
+        this._movingAnchor = target.getAttribute('data-position');
         const mouseMoveId = eventCenter.attachDOMEvent(
             document.body,
             'mousemove',
@@ -135,10 +135,10 @@ export class ImageResizeBar {
             'mouseup',
             this.mouseUp,
         );
-        this.resizing = true;
+        this._resizing = true;
         // Hide image toolbar
         eventCenter.emit('muya-image-toolbar', { reference: null });
-        this.eventId.push(mouseMoveId, mouseUpId);
+        this._eventId.push(mouseMoveId, mouseUpId);
     };
 
     mouseMove = (event: Event) => {
@@ -149,13 +149,13 @@ export class ImageResizeBar {
         const { clientX } = event;
         let width: number | string = '';
         let relativeAnchor: HTMLDivElement;
-        const image = this.reference!.querySelector('img');
+        const image = this._reference!.querySelector('img');
         if (!image)
             return;
 
-        switch (this.movingAnchor) {
+        switch (this._movingAnchor) {
             case 'left':
-                relativeAnchor = this.container.querySelector('.right')!;
+                relativeAnchor = this._container.querySelector('.right')!;
                 width = Math.max(
                     relativeAnchor.getBoundingClientRect().left + CIRCLE_RADIO - clientX,
                     50,
@@ -163,7 +163,7 @@ export class ImageResizeBar {
                 break;
 
             case 'right':
-                relativeAnchor = this.container.querySelector('.left')!;
+                relativeAnchor = this._container.querySelector('.left')!;
                 width = Math.max(
                     clientX - relativeAnchor.getBoundingClientRect().left - CIRCLE_RADIO,
                     50,
@@ -172,7 +172,7 @@ export class ImageResizeBar {
         }
         // Image width/height attribute must be an integer.
         width = Number.parseInt(String(width));
-        this.width = width;
+        this._width = width;
         image.setAttribute('width', String(width));
         this.update();
     };
@@ -180,28 +180,28 @@ export class ImageResizeBar {
     mouseUp = (event: Event) => {
         event.preventDefault();
         const { eventCenter } = this.muya;
-        if (this.eventId.length) {
-            for (const id of this.eventId)
+        if (this._eventId.length) {
+            for (const id of this._eventId)
                 eventCenter.detachDOMEvent(id);
 
-            this.eventId = [];
+            this._eventId = [];
         }
 
-        if (typeof this.width === 'number' && this.block && this.imageInfo) {
-            this.block.updateImage(this.imageInfo, 'width', String(this.width));
+        if (typeof this._width === 'number' && this._block && this._imageInfo) {
+            this._block.updateImage(this._imageInfo, 'width', String(this._width));
             this.hide();
         }
 
-        this.width = null;
-        this.resizing = false;
-        this.movingAnchor = null;
+        this._width = null;
+        this._resizing = false;
+        this._movingAnchor = null;
     };
 
     hide() {
         const { eventCenter } = this.muya;
-        const circles = this.container.querySelectorAll('.bar');
+        const circles = this._container.querySelectorAll('.bar');
         Array.from(circles).forEach(c => c.remove());
-        this.status = false;
+        this._status = false;
         eventCenter.emit('muya-float', this, false);
     }
 }

--- a/packages/core/src/ui/paragraphFrontMenu/index.ts
+++ b/packages/core/src/ui/paragraphFrontMenu/index.ts
@@ -48,9 +48,9 @@ const defaultOptions = {
 export class ParagraphFrontMenu extends BaseFloat {
     static pluginName = 'frontMenu';
     public reference: HTMLDivElement | null = null;
-    private oldVNode: VNode | null = null;
-    private block: Parent | null = null;
-    private frontMenuContainer: HTMLDivElement = document.createElement('div');
+    private _oldVNode: VNode | null = null;
+    private _block: Parent | null = null;
+    private _frontMenuContainer: HTMLDivElement = document.createElement('div');
 
     constructor(muya: Muya, options = {}) {
         const name = 'mu-front-menu';
@@ -59,7 +59,7 @@ export class ParagraphFrontMenu extends BaseFloat {
         Object.assign((this.container!.parentNode as HTMLElement).style, {
             overflow: 'visible',
         });
-        this.container!.appendChild(this.frontMenuContainer);
+        this.container!.appendChild(this._frontMenuContainer);
         this.listen();
     }
 
@@ -70,7 +70,7 @@ export class ParagraphFrontMenu extends BaseFloat {
 
         eventCenter.subscribe('muya-front-menu', ({ reference, block }) => {
             if (reference) {
-                this.block = block;
+                this._block = block;
                 this.reference = reference;
 
                 setTimeout(() => {
@@ -83,14 +83,14 @@ export class ParagraphFrontMenu extends BaseFloat {
         const enterLeaveHandler = () => {
             this.hide();
             this.reference = null;
-            this.block = null;
+            this._block = null;
         };
 
         eventCenter.attachDOMEvent(container!, 'mouseleave', enterLeaveHandler);
     }
 
     renderSubMenu(subMenu: IQuickInsertMenuItem['children']) {
-        const { block } = this;
+        const { _block: block } = this;
         const { i18n } = this.muya;
         const children = subMenu.map((menuItem) => {
             const { title, label, subTitle } = menuItem;
@@ -136,7 +136,7 @@ export class ParagraphFrontMenu extends BaseFloat {
     }
 
     render() {
-        const { oldVNode, frontMenuContainer, block } = this;
+        const { _oldVNode: oldVNode, _frontMenuContainer: frontMenuContainer, _block: block } = this;
         const { i18n } = this.muya;
         const { blockName } = block!;
         const children = FRONT_MENU.map(({ icon, label, text, shortCut }) => {
@@ -177,17 +177,17 @@ export class ParagraphFrontMenu extends BaseFloat {
             patch(oldVNode, vnode);
         else patch(frontMenuContainer, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     selectItem(event: Event, { label }: { label: string }) {
         event.preventDefault();
         event.stopPropagation();
 
-        if (!this.block)
+        if (!this._block)
             return;
 
-        const { block, muya } = this;
+        const { _block: block, muya } = this;
         const { editor } = muya;
         const oldState = block.getState();
         let cursorBlock = null;

--- a/packages/core/src/ui/previewToolBar/index.ts
+++ b/packages/core/src/ui/previewToolBar/index.ts
@@ -23,16 +23,16 @@ const defaultOptions = {
 
 export class PreviewToolBar extends BaseFloat {
     static pluginName = 'previewTools';
-    private oldVNode: VNode | null = null;
-    private block: HTMLBlock | MathBlock | null = null;
-    private iconContainer: HTMLDivElement = document.createElement('div');
+    private _oldVNode: VNode | null = null;
+    private _block: HTMLBlock | MathBlock | null = null;
+    private _iconContainer: HTMLDivElement = document.createElement('div');
 
     constructor(muya: Muya, options = {}) {
         const name = 'mu-preview-tools';
         const opts = Object.assign({}, defaultOptions, options);
         super(muya, name, opts);
         this.options = opts;
-        this.container?.appendChild(this.iconContainer);
+        this.container?.appendChild(this._iconContainer);
         this.floatBox?.classList.add('mu-preview-tools-container');
         this.listen();
     }
@@ -57,7 +57,7 @@ export class PreviewToolBar extends BaseFloat {
                 if (block.blockName === 'html-block' && this.muya.options.disableHtml)
                     return this.hide();
 
-                this.block = block;
+                this._block = block;
                 this.show(container);
                 this.render();
             }
@@ -70,7 +70,7 @@ export class PreviewToolBar extends BaseFloat {
     }
 
     render() {
-        const { iconContainer, oldVNode } = this;
+        const { _iconContainer: iconContainer, _oldVNode: oldVNode } = this;
         const children = ICONS.map((i) => {
             const iconWrapperSelector = 'div.icon-wrapper';
             const icon = h(
@@ -113,12 +113,12 @@ export class PreviewToolBar extends BaseFloat {
         else
             patch(iconContainer, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     selectItem(event: Event, i: typeof ICONS[number]) {
         event.preventDefault();
-        const { block } = this;
+        const { _block: block } = this;
         let cursorBlock = null;
         switch (i.type) {
             case 'edit': {

--- a/packages/core/src/ui/tableDragBar/index.ts
+++ b/packages/core/src/ui/tableDragBar/index.ts
@@ -102,12 +102,12 @@ const bottomOptions = {
 
 export class TableDragBar extends BaseFloat {
     static pluginName = 'tableDragBar';
-    private block: TableBodyCell | null = null;
-    private mouseTimer: ReturnType<typeof setTimeout> | null = null;
-    private dragEventIds: string[] = [];
-    private isDragTableBar: boolean = false;
-    private barType: 'bottom' | 'right' | null = null;
-    private dragInfo: IDragInfo | null = null;
+    private _block: TableBodyCell | null = null;
+    private _mouseTimer: ReturnType<typeof setTimeout> | null = null;
+    private _dragEventIds: string[] = [];
+    private _isDragTableBar: boolean = false;
+    private _barType: 'bottom' | 'right' | null = null;
+    private _dragInfo: IDragInfo | null = null;
 
     constructor(muya: Muya, options = {}) {
         const name = 'mu-table-drag-bar';
@@ -140,7 +140,7 @@ export class TableDragBar extends BaseFloat {
                 );
 
             if (
-                !this.isDragTableBar
+                !this._isDragTableBar
                 && !hasTableCell(els)
                 && (hasTableCell(aboveEls) || hasTableCell(leftEls))
             ) {
@@ -156,8 +156,8 @@ export class TableDragBar extends BaseFloat {
                     {},
                     barType === 'right' ? rightOptions : bottomOptions,
                 );
-                this.barType = barType;
-                this.block = cellBlock;
+                this._barType = barType;
+                this._block = cellBlock;
                 this.show(tableCellEl!);
                 this.render(barType);
             }
@@ -174,21 +174,21 @@ export class TableDragBar extends BaseFloat {
     mousedown = (event: Event) => {
         event.preventDefault();
         event.stopPropagation();
-        this.mouseTimer = setTimeout(() => {
+        this._mouseTimer = setTimeout(() => {
             this.startDrag(event);
-            this.mouseTimer = null;
+            this._mouseTimer = null;
         }, 300);
     };
 
     mouseup = (event: Event) => {
         event.preventDefault();
         event.stopPropagation();
-        const { container, barType } = this;
+        const { container, _barType: barType } = this;
         const { eventCenter } = this.muya;
 
-        if (this.mouseTimer) {
-            clearTimeout(this.mouseTimer);
-            this.mouseTimer = null;
+        if (this._mouseTimer) {
+            clearTimeout(this._mouseTimer);
+            this._mouseTimer = null;
             if (barType === 'right') {
                 eventCenter.emit('muya-table-bar', {
                     reference: {
@@ -197,7 +197,7 @@ export class TableDragBar extends BaseFloat {
                     tableInfo: {
                         barType,
                     },
-                    block: this.block,
+                    block: this._block,
                 });
             }
         }
@@ -205,16 +205,16 @@ export class TableDragBar extends BaseFloat {
 
     startDrag(event: Event) {
         event.preventDefault();
-        if (!isMouseEvent(event) || !this.block || !this.barType)
+        if (!isMouseEvent(event) || !this._block || !this._barType)
             return;
 
-        const { table } = this.block;
+        const { table } = this._block;
         const { eventCenter } = this.muya;
         const { clientX, clientY } = event;
-        const barType = this.barType;
-        const index = getIndex(barType, this.block);
+        const barType = this._barType;
+        const index = getIndex(barType, this._block);
         const aspects = calculateAspects(table, barType);
-        this.dragInfo = {
+        this._dragInfo = {
             table,
             clientX,
             clientY,
@@ -227,31 +227,31 @@ export class TableDragBar extends BaseFloat {
             offset: 0,
         };
 
-        for (const row of this.dragInfo.cells) {
+        for (const row of this._dragInfo.cells) {
             for (const cell of row) {
-                if (!this.dragInfo.dragCells.includes(cell))
+                if (!this._dragInfo.dragCells.includes(cell))
                     cell.classList.add('mu-cell-transform');
             }
         }
 
-        this.dragEventIds.push(
+        this._dragEventIds.push(
             eventCenter.attachDOMEvent(document, 'mousemove', this.docMousemove),
             eventCenter.attachDOMEvent(document, 'mouseup', this.docMouseup),
         );
     }
 
     docMousemove = (event: Event) => {
-        if (!this.dragInfo || !isMouseEvent(event))
+        if (!this._dragInfo || !isMouseEvent(event))
             return;
 
-        const { barType } = this.dragInfo;
+        const { barType } = this._dragInfo;
         const attrName = barType === 'bottom' ? 'clientX' : 'clientY';
-        const offset = (this.dragInfo.offset
-            = event[attrName] - this.dragInfo[attrName]);
+        const offset = (this._dragInfo.offset
+            = event[attrName] - this._dragInfo[attrName]);
         if (Math.abs(offset) < 5)
             return;
 
-        this.isDragTableBar = true;
+        this._isDragTableBar = true;
         this.calculateCurIndex();
         this.setDragTargetStyle();
         this.setSwitchStyle();
@@ -262,11 +262,11 @@ export class TableDragBar extends BaseFloat {
 
         const { eventCenter } = this.muya;
 
-        for (const id of this.dragEventIds)
+        for (const id of this._dragEventIds)
             eventCenter.detachDOMEvent(id);
 
-        this.dragEventIds = [];
-        if (!this.isDragTableBar)
+        this._dragEventIds = [];
+        if (!this._isDragTableBar)
             return;
 
         this.setDropTargetStyle();
@@ -279,11 +279,11 @@ export class TableDragBar extends BaseFloat {
     };
 
     calculateCurIndex = () => {
-        if (!this.dragInfo)
+        if (!this._dragInfo)
             return;
 
-        const { aspects, index } = this.dragInfo;
-        let { offset } = this.dragInfo;
+        const { aspects, index } = this._dragInfo;
+        let { offset } = this._dragInfo;
         let curIndex = index;
         const len = aspects.length;
         let i;
@@ -316,11 +316,11 @@ export class TableDragBar extends BaseFloat {
             }
         }
 
-        this.dragInfo.curIndex = Math.max(0, Math.min(curIndex, len - 1));
+        this._dragInfo.curIndex = Math.max(0, Math.min(curIndex, len - 1));
     };
 
     setDragTargetStyle = () => {
-        const { offset, barType, dragCells } = this.dragInfo!;
+        const { offset, barType, dragCells } = this._dragInfo!;
 
         for (const cell of dragCells) {
             if (!cell.classList.contains('mu-drag-cell')) {
@@ -333,10 +333,10 @@ export class TableDragBar extends BaseFloat {
     };
 
     setSwitchStyle = () => {
-        if (!this.dragInfo)
+        if (!this._dragInfo)
             return;
 
-        const { index, offset, curIndex, barType, aspects, cells } = this.dragInfo;
+        const { index, offset, curIndex, barType, aspects, cells } = this._dragInfo;
         const aspect = aspects[index];
         const len = aspects.length;
 
@@ -394,11 +394,11 @@ export class TableDragBar extends BaseFloat {
     };
 
     setDropTargetStyle = () => {
-        if (!this.dragInfo)
+        if (!this._dragInfo)
             return;
 
         const { dragCells, barType, curIndex, index, aspects, offset }
-            = this.dragInfo;
+            = this._dragInfo;
         let move = 0;
         let i;
         if (offset > 0) {
@@ -420,10 +420,10 @@ export class TableDragBar extends BaseFloat {
     };
 
     switchTableData = () => {
-        if (!this.dragInfo)
+        if (!this._dragInfo)
             return;
 
-        const { barType, index, curIndex, table, offset } = this.dragInfo;
+        const { barType, index, curIndex, table, offset } = this._dragInfo;
         if (index === curIndex)
             return;
 
@@ -508,8 +508,8 @@ export class TableDragBar extends BaseFloat {
     };
 
     resetDragTableBar = () => {
-        this.dragInfo = null;
-        this.isDragTableBar = false;
+        this._dragInfo = null;
+        this._isDragTableBar = false;
     };
 
     render(barType: BarType) {

--- a/packages/core/src/ui/tableRowColumMenu/index.ts
+++ b/packages/core/src/ui/tableRowColumMenu/index.ts
@@ -25,10 +25,10 @@ interface ITableInfo {
 
 export class TableRowColumMenu extends BaseFloat {
     static pluginName = 'tableBarTools';
-    private oldVNode: VNode | null = null;
-    private tableInfo: ITableInfo | null = null;
-    private block: TableBodyCell | null = null;
-    private tableBarContainer: HTMLDivElement = document.createElement('div');
+    private _oldVNode: VNode | null = null;
+    private _tableInfo: ITableInfo | null = null;
+    private _block: TableBodyCell | null = null;
+    private _tableBarContainer: HTMLDivElement = document.createElement('div');
 
     constructor(muya: Muya, options = {}) {
         const name = 'mu-table-bar-tools';
@@ -36,7 +36,7 @@ export class TableRowColumMenu extends BaseFloat {
         super(muya, name, opts);
 
         this.floatBox!.classList.add('mu-table-bar-tools');
-        this.container!.appendChild(this.tableBarContainer);
+        this.container!.appendChild(this._tableBarContainer);
         this.listen();
     }
 
@@ -47,8 +47,8 @@ export class TableRowColumMenu extends BaseFloat {
             'muya-table-bar',
             ({ reference, tableInfo, block }) => {
                 if (reference) {
-                    this.tableInfo = tableInfo;
-                    this.block = block;
+                    this._tableInfo = tableInfo;
+                    this._block = block;
                     this.show(reference);
                     this.render();
                 }
@@ -60,7 +60,7 @@ export class TableRowColumMenu extends BaseFloat {
     }
 
     render() {
-        const { tableInfo, oldVNode, tableBarContainer } = this;
+        const { _tableInfo: tableInfo, _oldVNode: oldVNode, _tableBarContainer: tableBarContainer } = this;
         const { i18n } = this.muya;
         const renderArray: MenuItem[] = toolList[tableInfo!.barType];
         const children = renderArray.map((item) => {
@@ -91,16 +91,16 @@ export class TableRowColumMenu extends BaseFloat {
         else
             patch(tableBarContainer, vnode);
 
-        this.oldVNode = vnode;
+        this._oldVNode = vnode;
     }
 
     selectItem(event: Event, item: MenuItem) {
         event.preventDefault();
         event.stopPropagation();
 
-        const { table, row } = this.block!;
+        const { table, row } = this._block!;
         const rowCount = (table.firstChild as TableInner).offset(row);
-        const columnCount = row.offset(this.block!);
+        const columnCount = row.offset(this._block!);
         const { location, action, target } = item;
 
         if (action === 'insert') {

--- a/packages/core/src/ui/tooltip/index.ts
+++ b/packages/core/src/ui/tooltip/index.ts
@@ -15,13 +15,13 @@ function position(source, ele) {
 }
 
 class Tooltip {
-    private muya: Muya;
-    private cache: WeakMap<HTMLElement, HTMLElement>;
+    private _muya: Muya;
+    private _cache: WeakMap<HTMLElement, HTMLElement>;
 
     constructor(muya) {
-        this.muya = muya;
-        this.cache = new WeakMap();
-        const { domNode, eventCenter } = this.muya;
+        this._muya = muya;
+        this._cache = new WeakMap();
+        const { domNode, eventCenter } = this._muya;
 
         eventCenter.attachDOMEvent(
             domNode,
@@ -33,8 +33,8 @@ class Tooltip {
     mouseOver(event) {
         const { target } = event;
         const toolTipTarget = target.closest('[data-tooltip]');
-        const { eventCenter } = this.muya;
-        if (toolTipTarget && !this.cache.has(toolTipTarget)) {
+        const { eventCenter } = this._muya;
+        if (toolTipTarget && !this._cache.has(toolTipTarget)) {
             const tooltip = toolTipTarget.getAttribute('data-tooltip');
             const tooltipEle = document.createElement('div');
             tooltipEle.textContent = tooltip;
@@ -42,7 +42,7 @@ class Tooltip {
             document.body.appendChild(tooltipEle);
             position(toolTipTarget, tooltipEle);
 
-            this.cache.set(toolTipTarget, tooltipEle);
+            this._cache.set(toolTipTarget, tooltipEle);
 
             setTimeout(() => {
                 tooltipEle.classList.add('active');
@@ -65,10 +65,10 @@ class Tooltip {
 
     mouseLeave(event) {
         const { target } = event;
-        if (this.cache.has(target)) {
-            const tooltipEle = this.cache.get(target);
+        if (this._cache.has(target)) {
+            const tooltipEle = this._cache.get(target);
             tooltipEle.remove();
-            this.cache.delete(target);
+            this._cache.delete(target);
         }
     }
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -185,7 +185,7 @@ export function sanitize(html: string, purifyOptions: Config, disableHtml: boole
  * TODO: @jocs remove in the future, because it's not used.
  * @param ele
  * @param id
- * @returns
+ * @returns A floating-ui-compatible virtual reference positioned at the element's bounding rect.
  */
 export function getParagraphReference(ele: HTMLElement, id: string) {
     const { x, y, left, top, bottom, height } = ele.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- Behavior-neutral cleanup of ESLint warnings #204 deliberately left behind. **71 → 16 warnings**, **0 errors throughout**.
- Fixes 41 `ts/naming-convention` private-member underscore-prefix warnings across `selection`, `state/*`, `block/scrollPage`, `block/gfm/taskListCheckbox`, and 8 files in `ui/*`. All renames stay within `private` scope; verified no external callers via grep.
- Fixes 3 `jsdoc/require-returns-description` warnings (`renderImageContainer`, `Selection.getSelection`, `getParagraphReference`) and the `interface Renderer` naming warning via a targeted eslint-disable, since it's TS declaration-merged with `class Renderer` and must share the class name.

The remaining 16 warnings are the intentionally-skipped set: 8 `complexity`, 1 `max-lines-per-function` (`Clipboard#cutHandler`), 5 `regexp/optimal-lookaround-quantifier` in the hand-tuned CommonMark/GFM parser regex (same family #204 left alone), and 2 global `Window`/`Element` interface extensions that cannot be renamed.

## Test plan
- [x] `pnpm lint` — 0 errors / 16 warnings (all expected-skipped items)
- [x] `pnpm lint:types` — clean
- [x] `pnpm test` — 12/12 pass
- [x] `pnpm build` — succeeds
- [ ] Sanity check: load examples (`pnpm dev`) and confirm editor still functions normally (table drag bar, image resize, emoji picker, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)