### PR TITLE
fix: backport marktext muya P0 crashes (PR-1a)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,154 @@
+# marktext 老 muya → @muyajs/core 新 muya 迁移追踪表
+
+调研方案在 `/Users/ransixi/.claude/plans/glimmering-hatching-lightning.md`。
+本表登记 P0~P3 共 ~80+ 条 commit 的迁移状态。
+
+状态字段：
+- `pending` — 待评估
+- `verified-not-applicable` — 已验证新架构下 bug 不存在 / 无意义
+- `test-only` — bug 复现失败，仅添加防御性回归测试
+- `fixed` — 已实施修复 + 测试
+- `skipped` — 决定不做（如纯 marktext 应用层）
+
+PR 分组对应方案第三节的 5 个系列：
+- **PR-1a** 安全 + 已确认 crash（非 XSS）
+- **PR-1b** XSS 四联（独立 PR 便于安全审计）
+- **PR-2** Parser 合规性（含 footnote 测试基线）
+- **PR-3** 编辑 / 光标 / IME
+- **PR-4** Clipboard / 富文本
+- **PR-5** P3 体验特性（按需）
+
+---
+
+## P0 — 安全 / 数据损坏 / crash
+
+| Hash | 范畴 | 说明 | PR | 状态 |
+|---|---|---|---|---|
+| 9884342f | table | normalizeTable 行单元数 > 表头 crash | PR-1a | `fixed`（含 3 个回归测试） |
+| 9ffc5b1b | heading | 空 heading slug crash | PR-1a | `verified-not-applicable`（新仓无 slugger） |
+| bca2ed62 | image | loadImageAsync 失败永久缓存 | PR-1a | `fixed`（含 3 个回归测试） |
+| 36e825c2 | image | getImageInfo 空 firstChild | PR-1a | `verified-not-applicable`（新仓 getImageInfo 不读 firstChild） |
+| fed1dac4 | xss | HTML 表格粘贴 XSS | PR-1b | `pending` |
+| 0dd09cc6 | xss | code lang + 超链接 XSS | PR-1b | `pending` |
+| c959d185 | xss | Mermaid XSS | PR-1b | `pending` |
+| dc54c7b6 | xss | 代码块未 escape HTML | PR-1b | `pending` |
+| c47795e4 | xss | XSS + Electron（部分电子相关跳过） | PR-1b | `pending` |
+| 0baf2e9e / 7de33f11 | xss | #1390 XSS | PR-1b | `pending` |
+| 6293d408 | table-ctrl | 老 tableBlockCtrl 修复，新仓无同名结构 | 待评估 | `pending`（建议 PR-3 验证） |
+| f99addd2 | table-ctrl | selectedTableCells 清理，新仓无对应 | 待评估 | `pending`（建议 PR-3 验证） |
+| 0a3fda63 + 2754e393 + 4b362e52 | architecture | post-refactor 修复合集（拆条） | 待拆 | `pending` |
+
+## P1 — Parser / 渲染正确性
+
+| Hash | 范畴 | 说明 | PR | 状态 |
+|---|---|---|---|---|
+| 1ecc3601 | parser | footnote 解析 + 510 行测试基线 | PR-2 | `pending` |
+| 23435ce6 | parser | 任务列表缩进 | PR-2 | `pending` |
+| 57cd04c5 | parser | CommonMark example 475 | PR-2 | `pending` |
+| ad5ddbf9 | parser | GFM example 558 | PR-2 | `pending` |
+| 372fe02f | parser | list 解析 #870 | PR-2 | `pending` |
+| 8891287b | parser | paragraph → list 转换 | PR-2 | `pending` |
+| 270d33f6 | parser | list item lexer/parser | PR-2 | `pending` |
+| 04834032 | parser | tab 缩进 list | PR-2 | `pending` |
+| 240d64aa | parser | 合并不同类型 list #706 | PR-2 | `pending` |
+| 02841ffd | parser | list 后续段落归属 | PR-2 | `pending` |
+| 5f191681 | parser | blockquote 内 list | PR-2 | `pending` |
+| 70d49c30 | parser | `-foo` 误识 list item | PR-2 | `pending` |
+| 7b7a9424 | math | math block 嵌套 | PR-2 | `pending` |
+| d937fac0 | inline | inline 语法 | PR-2 | `pending` |
+| 9c2f6cb3 | inline | inline math 样式 | PR-2 | `pending` |
+| 6dfa7938 | inline | inline math selection | PR-2 | `pending` |
+| d9f64bab | inline | reference link 渲染 | PR-2 | `pending` |
+| b8e2cd82 | inline | inline html renderer | PR-2 | `pending` |
+| 962fdf35 | inline | heading emoji 偏移 | PR-2 | `pending` |
+| 8e32838b | inline | 上/下标 | PR-2 | `pending` |
+| c0853f64 | inline | auto link / extension | PR-2 | `pending` |
+| 1c42555a | block | 粘贴多行进 heading | PR-4 | `pending` |
+| dec7502e | block | setext heading | PR-2 | `pending` |
+| f00da152 | block | 嵌套块插表 crash | PR-2 | `pending` |
+| 9cb2cbe8 | toc | TOC 更新（如做 TOC 参考） | PR-5 | `pending` |
+
+## P2 — 编辑 / 光标 / 选择 / IME
+
+| Hash | 范畴 | 说明 | PR | 状态 |
+|---|---|---|---|---|
+| 6f1e733c | cursor | codeblock 光标 #2013 | PR-3 | `pending` |
+| 0a3efbf8 | selection | 文本选区 #622 | PR-3 | `pending` |
+| 7936e3f4 | selection | 选区无法取消 #636 | PR-3 | `pending` |
+| 02dbb8af | search | 嵌套 block 搜索 | PR-3 | `pending` |
+| 4c517b16 | search | search group | PR-3 | `pending` |
+| 1a4844f8 | history | undo/redo 不触发 change | PR-3 | `pending` |
+| 16d61572 | render | partialRender 光标已移除 block | PR-3 | `pending` |
+| 701fb9ae | text | text 删除追加 soft-line | PR-3 | `pending` |
+| 0dc4b415 | table | cell backspace | PR-3 | `pending` |
+| 5fb130d9 | table | shift+tab 表格导航 | PR-3 | `pending` |
+| 9e32c4a0 | table | cursor → next cell index 0 | PR-3 | `pending` |
+| 0028a4bc | table | cell copy 异常 | PR-3 | `pending` |
+| 3fa8a9ae | autopair | inline code 内禁用 | PR-3 | `pending` |
+| 4278362f | autopair | inline math 内禁用 | PR-3 | `pending` |
+| bbea7eca | autopair | 优化自动补全 | PR-3 | `pending` |
+| 358fa83d | autopair | 引号自动配对 | PR-3 | `pending` |
+| 6a50b5cb | tasklist | 切换 task-list 光标跳末尾 | PR-3 | `pending` |
+| c3f128e7 | tasklist | copy 保留勾选态 | PR-4 | `pending` |
+| edbab6ed | ime | 中文输入误删 | PR-3 | `pending` |
+| 67e18176 | ime | 中文回车多行 | PR-3 | `pending` |
+| 8a7e6559 | ime | compose bug | PR-3 | `pending` |
+| 63642d39 | typing | 回车 typewriter 抖动 | PR-3 | `pending` |
+| 6b3ead95 | keyboard | 非 US 键盘 | PR-3 | `pending` |
+| ed1b3354 | keyboard | 图片选中按 delete | PR-3 | `pending` |
+| b925f7d6 | clipboard | 移动端 cut | PR-4 | `pending` |
+| 393139e5 | clipboard | clipboard 过度 sanitize | PR-4 | `pending` |
+| 54a3b585 | clipboard | 粘贴 HTML escape | PR-4 | `pending` |
+| 485fcfe0 | clipboard | image paste handler 不执行 | PR-4 | `pending` |
+| 5b1cd85d | clipboard | 末尾 html block 粘贴错误 | PR-4 | `pending` |
+| fb8fca7b | clipboard | copy/paste list | PR-4 | `pending` |
+| 067ec485 | clipboard | HTML paste handler | PR-4 | `pending` |
+| ef59a743 | clipboard | 富文本复制 | PR-4 | `pending` |
+| c841facd | clipboard | 空内容不写剪贴板 | PR-4 | `pending` |
+
+## P3 — 体验特性（PR-5 按需）
+
+| Hash | 类型 | 说明 | 状态 |
+|---|---|---|---|
+| 7377de3c | feat | footnote 完整链路 | `pending` |
+| ab97336e | feat | highlight 菜单 | `pending` |
+| 1ef0d016 | feat | linkTools unlink/jump | `pending` |
+| cb25b3d4 | feat | linkTools 支持 `<a>` 与 ref link | `pending` |
+| 141d25d8 | feat | 粘贴链接抓页面标题 | `pending` |
+| d26f5092 | feat | image resize + inline/block 切换 | `pending` |
+| cb7be189 | feat | inline image / small image | `pending` |
+| 9eff8248 | feat | focus / blur 事件 | `pending` |
+| 8474a997 | feat | prism 语言别名 | `pending` |
+| 8af9605e | feat | code block Solidity 等语言 | `pending` |
+| 47cb2bbe | feat | indent code block | `pending` |
+| 7aa0d1bf | feat | code block 复制按钮 | `pending` |
+| a028a7c2 | feat | code block 行号 | `pending` |
+| ef9fe756 | feat | underline 格式 | `pending` |
+| 81af43be | feat | quick insert hint 隐藏 | `pending` |
+| c0c8ea4b | feat | 打开外链 / 本地 md | `pending` |
+| f3b53427 | feat | 跳光标到末尾再格式化 | `pending` |
+| efd38644 | feat | 长 footnote 编号 | `pending` |
+| 318bfc6a / fc89d04a / 37b96c88 | feat | footnote 系列 | `pending` |
+
+## P4 — 明确不迁
+
+- marktext 应用层（Electron / preferences / IPC / 文件系统 / theme / print / 键位设置 UI）
+- 老 muya CSS 主题
+- 已被新架构结构性解决的 partialRender / contentState ctrl 系列
+- 纯 lint / 格式化 / 依赖升级
+- marktext i18n 文案
+
+---
+
+## 进度统计
+
+| PR | 计划条数 | 已完成 | 占比 |
+|---|---|---|---|
+| PR-1a | 6 | 4 | 67%（2 fixed + 2 verified-not-applicable，2 转 PR-3） |
+| PR-1b | 6 | 0 | 0% |
+| PR-2 | 25 | 0 | 0% |
+| PR-3 | 19 | 0 | 0% |
+| PR-4 | 13 | 0 | 0% |
+| PR-5 | 19+ | 0 | 0% |
+
+最后更新：2026-05-20

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -370,12 +370,15 @@ export const punctuation = [
 ];
 // export const isInElectron = (window.process as any)?.type === "renderer";
 export const IMAGE_EXT_REG = /\.(jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
-export const isFirefox = (navigator.userAgent.includes('Firefox'));
+export const isFirefox
+    = typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox');
 export const isOsx
-    = window && window.navigator && /Mac/.test(window.navigator.userAgent);
+    = typeof window !== 'undefined'
+        && window.navigator
+        && /Mac/.test(window.navigator.userAgent);
 export const isWin
-    = window
-        && window.navigator.userAgent
+    = typeof window !== 'undefined'
+        && window.navigator
         && /win32|wow32|win64|wow64/i.test(window.navigator.userAgent);
 // http[s] (domain or IPv4 or localhost or IPv6) [port] /not-white-space
 export const URL_REG

--- a/packages/core/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
+++ b/packages/core/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import loadImageAsync from '../loadImageAsync';
+
+vi.mock('../../../utils/image', () => ({
+    loadImage: vi.fn(() => new Promise(() => {})), // never resolves; we only test the sync decision
+}));
+
+vi.mock('../../../utils/dom', () => ({
+    insertAfter: vi.fn(),
+    operateClassName: vi.fn(),
+}));
+
+interface FakeRenderer {
+    loadImageMap: Map<string, { id: string; isSuccess: boolean; width?: number; height?: number }>;
+    urlMap: Map<string, string>;
+}
+
+function makeRenderer(): FakeRenderer {
+    return {
+        loadImageMap: new Map(),
+        urlMap: new Map(),
+    };
+}
+
+// Regression for marktext commit bca2ed62 (#3001 / #3010):
+// "Internal image cache isn't reset if failed to load".
+// The previous cache-key check `!this.loadImageMap.has(src)` would skip
+// re-loading even after a transient failure, poisoning the entry forever.
+// The fix retries whenever the cached entry has `isSuccess === false`.
+describe('loadImageAsync — failed cache should retry', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('returns the cached info when the previous load succeeded', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        const r = makeRenderer();
+        r.loadImageMap.set('https://example.com/a.png', {
+            id: 'mu-cached-success',
+            isSuccess: true,
+            width: 100,
+            height: 50,
+        });
+
+        const out = loadImageAsync.call(
+            r as unknown as Parameters<typeof loadImageAsync>[0] extends never ? never : any,
+            { isUnknownType: false, src: 'https://example.com/a.png' },
+            {},
+        );
+
+        expect(out).toEqual({
+            id: 'mu-cached-success',
+            isSuccess: true,
+            width: 100,
+            height: 50,
+        });
+        expect(loadImage).not.toHaveBeenCalled();
+    });
+
+    it('re-triggers loadImage when the previous load failed', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        const r = makeRenderer();
+        r.loadImageMap.set('https://example.com/b.png', {
+            id: 'mu-cached-fail',
+            isSuccess: false,
+        });
+
+        const out = loadImageAsync.call(
+            r as any,
+            { isUnknownType: false, src: 'https://example.com/b.png' },
+            {},
+        );
+
+        // a fresh id is generated for the new attempt
+        expect(out.id).not.toBe('mu-cached-fail');
+        // the loader was invoked again
+        expect(loadImage).toHaveBeenCalledTimes(1);
+        expect(loadImage).toHaveBeenCalledWith('https://example.com/b.png', false);
+    });
+
+    it('triggers loadImage when nothing is cached', async () => {
+        const { loadImage } = await import('../../../utils/image');
+        const r = makeRenderer();
+
+        loadImageAsync.call(
+            r as any,
+            { isUnknownType: false, src: 'https://example.com/c.png' },
+            {},
+        );
+
+        expect(loadImage).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/core/src/inlineRenderer/renderer/loadImageAsync.ts
+++ b/packages/core/src/inlineRenderer/renderer/loadImageAsync.ts
@@ -20,7 +20,10 @@ export default function loadImageAsync(
     let w;
     let h;
 
-    if (!this.loadImageMap.has(src)) {
+    const cached = this.loadImageMap.get(src);
+    // Retry when the previous load failed: a transient failure should not
+    // permanently poison the cache (marktext#3001 / #3010, commit bca2ed62).
+    if (!cached || !cached.isSuccess) {
         id = getUniqueId();
         loadImage(src, isUnknownType)
             .then(({ url, width, height }) => {
@@ -90,11 +93,10 @@ export default function loadImageAsync(
             });
     }
     else {
-        const imageInfo = this.loadImageMap.get(src)!;
-        id = imageInfo.id;
-        isSuccess = imageInfo.isSuccess;
-        w = imageInfo.width;
-        h = imageInfo.height;
+        id = cached.id;
+        isSuccess = cached.isSuccess;
+        w = cached.width;
+        h = cached.height;
     }
 
     return { id, isSuccess, width: w, height: h };

--- a/packages/core/src/state/__tests__/stateToMarkdown.spec.ts
+++ b/packages/core/src/state/__tests__/stateToMarkdown.spec.ts
@@ -1,0 +1,74 @@
+import type { ITableCellState, ITableRowState, ITableState } from '../types';
+import { describe, expect, it } from 'vitest';
+import ExportMarkdown from '../stateToMarkdown';
+
+function cell(text: string, align = 'none'): ITableCellState {
+    return {
+        name: 'table.cell',
+        meta: { align },
+        text,
+    };
+}
+
+function row(cells: ITableCellState[]): ITableRowState {
+    return {
+        name: 'table.row',
+        children: cells,
+    };
+}
+
+function table(rows: ITableRowState[]): ITableState {
+    return {
+        name: 'table',
+        children: rows,
+    };
+}
+
+// Regression for marktext commit 9884342f (#4222 / #4190).
+// `normalizeTable` previously crashed with
+//   TypeError: Cannot read properties of undefined (reading 'width')
+// when a body row had more cells than the header, or
+//   TypeError: Cannot read properties of undefined (reading 'length')
+// when a body row had fewer cells than the header.
+describe('serializeTable — row width mismatch', () => {
+    it('does not crash when a body row has more cells than the header', () => {
+        const state = table([
+            row([cell('a'), cell('b')]),
+            row([cell('1'), cell('2'), cell('3'), cell('4')]),
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+
+        expect(md).toContain('| a');
+        expect(md).toContain('| b');
+        expect(md).not.toContain('| 3');
+        expect(md).not.toContain('| 4');
+    });
+
+    it('does not crash when a body row has fewer cells than the header', () => {
+        const state = table([
+            row([cell('a'), cell('b'), cell('c')]),
+            row([cell('1')]),
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+
+        expect(md).toContain('| a');
+        expect(md).toContain('| c');
+        expect(md).toContain('| 1');
+    });
+
+    it('serialises a well-formed table normally', () => {
+        const state = table([
+            row([cell('a'), cell('b')]),
+            row([cell('1'), cell('2')]),
+        ]);
+
+        const md = new ExportMarkdown().generate([state]);
+
+        expect(md).toContain('| a');
+        expect(md).toContain('| b');
+        expect(md).toContain('| 1');
+        expect(md).toContain('| 2');
+    });
+});

--- a/packages/core/src/state/stateToMarkdown.ts
+++ b/packages/core/src/state/stateToMarkdown.ts
@@ -354,7 +354,6 @@ export default class ExportMarkdown {
     serializeTable(state: ITableState, indent: string) {
         const result: string[] = [];
         const row = state.children.length;
-        const column = state.children[0].children.length;
         const tableData = [];
 
         for (const rowState of state.children) {
@@ -372,7 +371,8 @@ export default class ExportMarkdown {
         let j;
 
         for (i = 0; i < row; i++) {
-            for (j = 0; j < column; j++) {
+            const cells = Math.min(tableData[i].length, columnWidth.length);
+            for (j = 0; j < cells; j++) {
                 columnWidth[j].width = Math.max(
                     columnWidth[j].width,
                     tableData[i][j].length + 2,
@@ -385,6 +385,7 @@ export default class ExportMarkdown {
                 = `${indent
                 }|${
                     r
+                        .slice(0, columnWidth.length)
                         .map((cell, j) => {
                             const raw = ` ${cell + ' '.repeat(columnWidth[j].width)}`;
 


### PR DESCRIPTION
## Summary

First PR in a multi-PR migration that backports 8 years of marktext muya
bugfixes and features into the rewritten TS core.

This PR ships the two **already-verified P0 crashes** that exist in both
old and new muya, with regression tests:

- **normalizeTable row mismatch** — malformed tables (body row count ≠
  header) crashed with `Cannot read properties of undefined (reading 'width' / 'length')`.
  Backported from marktext [9884342f](https://github.com/marktext/marktext/commit/9884342f) (#4222 / #4190).
- **loadImageAsync failed cache** — a failed image load permanently
  poisoned the in-memory cache; renaming or replacing a broken src never
  re-triggered a load. Backported from marktext [bca2ed62](https://github.com/marktext/marktext/commit/bca2ed62) (#3001 / #3010).

Two other P0 candidates were verified to **not apply** to the new
architecture and are documented as such in MIGRATION.md (empty heading
slug — no slugger exists; getImageInfo firstChild — different shape).
Two table-controller fixes were deferred to a later PR after the new
table model is exercised end-to-end.

A minor side change makes `isFirefox / isOsx / isWin` in `config/index.ts`
guard against `typeof window === 'undefined'` so the new vitest suites
can import state and inline-renderer modules in a plain Node environment
without a DOM polyfill.

## Migration tracking

`MIGRATION.md` (new) catalogues ~80 marktext fix/feat commits across
P0 (crash + XSS), P1 (parser correctness), P2 (cursor/IME/clipboard),
P3 (features). Each row is tagged with target PR and status:
`pending / verified-not-applicable / test-only / fixed / skipped`.

Full research plan and prioritised commit list:
`.claude/plans/glimmering-hatching-lightning.md` (local).

## Test plan

- [x] `pnpm --filter @muyajs/core test` — 4 files / **18 tests** pass (6 new)
- [x] `pnpm lint:types` — clean
- [x] `pnpm check-circular` — no circular deps
- [ ] Reviewer: confirm fix-level matches marktext intent (linked commits)
- [ ] Reviewer: sanity-check `MIGRATION.md` priorities before PR-1b (XSS) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)