### PR TITLE
fix: backport marktext muya clipboard/paste fixes (PR-4)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -105,7 +105,7 @@ PR 分组对应方案第三节的 5 个系列：
 | fb8fca7b | clipboard | copy/paste list | PR-4 | `pending` |
 | 067ec485 | clipboard | HTML paste handler | PR-4 | `pending` |
 | ef59a743 | clipboard | 富文本复制 | PR-4 | `pending` |
-| c841facd | clipboard | 空内容不写剪贴板 | PR-4 | `pending` |
+| c841facd | clipboard | 空内容不写剪贴板 | PR-4b | `fixed`（含 6 个回归测试） |
 
 ## P3 — 体验特性（PR-5 按需）
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -64,7 +64,7 @@ PR 分组对应方案第三节的 5 个系列：
 | 962fdf35 | inline | heading emoji 偏移 | PR-2 | `pending` |
 | 8e32838b | inline | 上/下标 | PR-2 | `pending` |
 | c0853f64 | inline | auto link / extension | PR-2 | `pending` |
-| 1c42555a | block | 粘贴多行进 heading | PR-4 | `pending` |
+| 1c42555a | block | 粘贴多行进 heading | PR-4a | `fixed`（提取 `mergePasteIntoHeading` 纯函数，6 个测试） |
 | dec7502e | block | setext heading | PR-2 | `pending` |
 | f00da152 | block | 嵌套块插表 crash | PR-2 | `pending` |
 | 9cb2cbe8 | toc | TOC 更新（如做 TOC 参考） | PR-5 | `pending` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -115,7 +115,7 @@ PR 分组对应方案第三节的 5 个系列：
 | ab97336e | feat | highlight 菜单 | `pending` |
 | 1ef0d016 | feat | linkTools unlink/jump | `pending` |
 | cb25b3d4 | feat | linkTools 支持 `<a>` 与 ref link | `pending` |
-| 141d25d8 | feat | 粘贴链接抓页面标题 | `pending` |
+| 141d25d8 | feat | 粘贴链接抓页面标题 | PR-4c | `fixed`（`res.json()`→`res.text()`，5 个测试） |
 | d26f5092 | feat | image resize + inline/block 切换 | `pending` |
 | cb7be189 | feat | inline image / small image | `pending` |
 | 9eff8248 | feat | focus / blur 事件 | `pending` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -90,21 +90,21 @@ PR 分组对应方案第三节的 5 个系列：
 | bbea7eca | autopair | 优化自动补全 | PR-3 | `pending` |
 | 358fa83d | autopair | 引号自动配对 | PR-3 | `pending` |
 | 6a50b5cb | tasklist | 切换 task-list 光标跳末尾 | PR-3 | `pending` |
-| c3f128e7 | tasklist | copy 保留勾选态 | PR-4 | `pending` |
+| c3f128e7 | tasklist | copy 保留勾选态 | PR-4b | `verified-not-applicable`：marktext fix 是其 DOM-based copy 的 checkbox 注入边界，新仓走 marked 渲染（task-list `[x]/[ ]` → `<input checked>`），渲染层一致 |
 | edbab6ed | ime | 中文输入误删 | PR-3 | `pending` |
 | 67e18176 | ime | 中文回车多行 | PR-3 | `pending` |
 | 8a7e6559 | ime | compose bug | PR-3 | `pending` |
 | 63642d39 | typing | 回车 typewriter 抖动 | PR-3 | `pending` |
 | 6b3ead95 | keyboard | 非 US 键盘 | PR-3 | `pending` |
 | ed1b3354 | keyboard | 图片选中按 delete | PR-3 | `pending` |
-| b925f7d6 | clipboard | 移动端 cut | PR-4 | `pending` |
-| 393139e5 | clipboard | clipboard 过度 sanitize | PR-4 | `pending` |
-| 54a3b585 | clipboard | 粘贴 HTML escape | PR-4 | `pending` |
-| 485fcfe0 | clipboard | image paste handler 不执行 | PR-4 | `pending` |
-| 5b1cd85d | clipboard | 末尾 html block 粘贴错误 | PR-4 | `pending` |
-| fb8fca7b | clipboard | copy/paste list | PR-4 | `pending` |
+| b925f7d6 | clipboard | 移动端 cut | PR-4b | `verified-not-applicable`：新仓 `cutHandler` 起手即 `if (selection == null) return;`，等价 marktext 的 `if (!start || !end) return;` 守卫 |
+| 393139e5 | clipboard | clipboard 过度 sanitize | PR-4b | `verified-not-applicable`：新仓 `getClipboardData` 单块/多块路径都 `text = substring(...)`/`mdGenerator.generate(...)` 直出，无 `escapeHtml`；含 2 个防御测试 |
+| 54a3b585 | clipboard | 粘贴 HTML escape | PR-4a | `verified-not-applicable`：`utils/paste.ts` 已 `sanitize(html, PREVIEW_DOMPURIFY_CONFIG, false)` |
+| 485fcfe0 | clipboard | image paste handler 不执行 | PR-4a | `verified-not-applicable`：新仓 pasteHandler 无 image paste 路径；进入 paste handler 后不会因 `!text && !html` 早退 |
+| 5b1cd85d | clipboard | 末尾 html block 粘贴错误 | PR-4a | `pending`：需 examples 手测（marktext 在 contentState 走 `getLastBlock` 递归选末块；新仓多段粘贴直接 `insertAfter` 不递归子树，结构上不会因 html-block `editable===false` 选错末块） |
+| fb8fca7b | clipboard | copy/paste list | PR-4b | `verified-not-applicable`：turndown `paragraph`/`listItem` 规则已在 `utils/turndownService/index.ts`；checkbox 注入是 marktext DOM-based copy 特有，新仓走 marked 渲染不需要 |
 | 067ec485 | clipboard | HTML paste handler | PR-4a | `partial-fixed`：text-only `<table>...</table>` 现在升级到 html 槽走 HtmlToMarkdown；recursion 与 pasteImage 分支新架构不适用（无 pasteImage） |
-| ef59a743 | clipboard | 富文本复制 | PR-4 | `pending` |
+| ef59a743 | clipboard | 富文本复制 | PR-4b | `verified-not-applicable`：copyHandler 'normal' 已 `setData('text/html', html); setData('text/plain', text)`；`getClipBoardHtml` 经 marked 渲染 |
 | c841facd | clipboard | 空内容不写剪贴板 | PR-4b | `fixed`（含 6 个回归测试） |
 
 ## P3 — 体验特性（PR-5 按需）
@@ -149,7 +149,9 @@ PR 分组对应方案第三节的 5 个系列：
 | PR-1b | 7 | 6 | 86%（1 fixed + 4 verified-not-applicable + 1 skipped；防御测试 15 个） |
 | PR-2 | 25 | 0 | 0% |
 | PR-3 | 19 | 0 | 0% |
-| PR-4 | 13 | 0 | 0% |
-| PR-5 | 19+ | 0 | 0% |
+| PR-4a (粘贴) | 5 | 4 | 80%（2 fixed + 2 verified-not-applicable；1 留 examples 手测） |
+| PR-4b (复制) | 7 | 7 | 100%（1 fixed + 6 verified-not-applicable；防御测试 8 个） |
+| PR-4c (P3 抓标题) | 1 | 1 | 100%（fixed，5 个测试） |
+| PR-5 | 18+ | 0 | 0% |
 
 最后更新：2026-05-20

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -103,7 +103,7 @@ PR 分组对应方案第三节的 5 个系列：
 | 485fcfe0 | clipboard | image paste handler 不执行 | PR-4 | `pending` |
 | 5b1cd85d | clipboard | 末尾 html block 粘贴错误 | PR-4 | `pending` |
 | fb8fca7b | clipboard | copy/paste list | PR-4 | `pending` |
-| 067ec485 | clipboard | HTML paste handler | PR-4 | `pending` |
+| 067ec485 | clipboard | HTML paste handler | PR-4a | `partial-fixed`：text-only `<table>...</table>` 现在升级到 html 槽走 HtmlToMarkdown；recursion 与 pasteImage 分支新架构不适用（无 pasteImage） |
 | ef59a743 | clipboard | 富文本复制 | PR-4 | `pending` |
 | c841facd | clipboard | 空内容不写剪贴板 | PR-4b | `fixed`（含 6 个回归测试） |
 

--- a/packages/core/src/clipboard/__tests__/copyHandler.spec.ts
+++ b/packages/core/src/clipboard/__tests__/copyHandler.spec.ts
@@ -1,0 +1,104 @@
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+
+// The clipboard module pulls in CodeBlockContent → utils/prism which touches
+// `window` at import time. Stub the prism shim so the test can run under Node.
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const ClipboardModule = await import('../index');
+const Clipboard = ClipboardModule.default;
+
+// Regression for marktext commit c841facd (#3130).
+// `Clipboard.copyHandler` previously wrote the clipboard even when the
+// selection produced an empty string, clobbering whatever the user had
+// stashed there from another source. The fix mirrors native behavior:
+// skip `setData` entirely when there's nothing to copy.
+
+function makeEvent() {
+    const setData = vi.fn();
+    return {
+        event: {
+            clipboardData: {
+                setData,
+            },
+        } as unknown as ClipboardEvent,
+        setData,
+    };
+}
+
+function makeClipboard(html: string, text: string) {
+    const clipboard = new Clipboard({} as Muya);
+    clipboard.getClipboardData = () => ({ html, text });
+    return clipboard;
+}
+
+describe('clipboard.copyHandler — skip empty clipboard writes', () => {
+    it('normal copy: does not call setData when both html and text are empty', () => {
+        const clipboard = makeClipboard('', '');
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+
+    it('normal copy: writes both formats when text is non-empty', () => {
+        const clipboard = makeClipboard('<p>hi</p>', 'hi');
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).toHaveBeenCalledWith('text/html', '<p>hi</p>');
+        expect(setData).toHaveBeenCalledWith('text/plain', 'hi');
+    });
+
+    it('copyAsMarkdown: does not call setData when text is empty', () => {
+        const clipboard = makeClipboard('', '');
+        clipboard.copyType = 'copyAsMarkdown';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+
+    it('copyAsHtml: does not call setData when html is empty', () => {
+        const clipboard = makeClipboard('', '');
+        clipboard.copyType = 'copyAsHtml';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+
+    it('copyCodeContent: does not call setData when copyInfo is empty', () => {
+        const clipboard = new Clipboard({} as Muya);
+        clipboard.copyType = 'copyCodeContent';
+        clipboard.copyInfo = '';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).not.toHaveBeenCalled();
+    });
+
+    it('copyCodeContent: writes plain text when copyInfo is non-empty', () => {
+        const clipboard = new Clipboard({} as Muya);
+        clipboard.copyType = 'copyCodeContent';
+        clipboard.copyInfo = 'console.log("x")';
+        const { event, setData } = makeEvent();
+
+        clipboard.copyHandler(event);
+
+        expect(setData).toHaveBeenCalledWith('text/html', '');
+        expect(setData).toHaveBeenCalledWith('text/plain', 'console.log("x")');
+    });
+});

--- a/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -1,0 +1,63 @@
+import type { Muya } from '../../muya';
+import { describe, expect, it, vi } from 'vitest';
+
+// Same prism stub as copyHandler.spec — the import graph touches `window`.
+vi.mock('../../utils/prism/index', () => ({
+    default: {},
+    walkTokens: () => null,
+    loadedLanguages: new Set(),
+    transformAliasToOrigin: (s: string) => s,
+    loadLanguage: () => null,
+    search: () => [],
+}));
+
+const Clipboard = (await import('../index')).default;
+
+// Regression for marktext commits 393139e5 (#2197 — "unnecessary character
+// sanitation on clipboard output") and dc54c7b6-adjacent code-content path:
+// the text copied to the clipboard from a single-block selection MUST NOT be
+// HTML-escaped. The user copied `<`, they should get `<` on the clipboard,
+// not `&lt;`.
+
+function fakeMuya() {
+    return {
+        options: { frontMatter: true },
+    } as unknown as Muya;
+}
+
+function selectionOver(text: string, begin: number, end: number) {
+    return {
+        isSelectionInSameBlock: true,
+        anchor: { offset: begin },
+        focus: { offset: end },
+        anchorBlock: { text } as any,
+        focusBlock: { text } as any,
+    };
+}
+
+function makeClipboard(text: string, begin: number, end: number) {
+    const clipboard = new Clipboard(fakeMuya());
+    Object.defineProperty(clipboard, 'selection', {
+        get: () => ({ getSelection: () => selectionOver(text, begin, end) }),
+    });
+    Object.defineProperty(clipboard, 'scrollPage', { get: () => null });
+    return clipboard;
+}
+
+describe('clipboard.getClipboardData — single-block selection is not HTML-escaped', () => {
+    it('preserves angle brackets and ampersands verbatim in text/plain', () => {
+        const clipboard = makeClipboard('a <b> & "c"', 0, 11);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe('a <b> & "c"');
+    });
+
+    it('returns empty text when the selection is collapsed', () => {
+        const clipboard = makeClipboard('hello', 2, 2);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe('');
+    });
+});

--- a/packages/core/src/clipboard/__tests__/mergePasteIntoHeading.spec.ts
+++ b/packages/core/src/clipboard/__tests__/mergePasteIntoHeading.spec.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { mergePasteIntoHeading } from '../mergePasteIntoHeading';
+
+// Regression for marktext commit 1c42555a (#671):
+// "allow pasting multi-line text into a heading".
+//
+// Old behaviour: pasting multi-paragraph markdown into a heading kept the
+// heading untouched and inserted ALL paragraphs as new blocks below.
+// Expected behaviour: the first paragraph is merged into the heading (so
+// the heading still feels like one continuous line at the cursor position),
+// and the remaining paragraphs become regular paragraph blocks below the
+// heading.
+//
+// `mergePasteIntoHeading` is the pure helper that decides whether to merge
+// and, if so, mutates the heading's text and returns the remaining states.
+
+interface FakeContent {
+    text: string;
+    updated: boolean;
+    update: () => void;
+}
+
+function content(text: string): FakeContent {
+    const block: FakeContent = {
+        text,
+        updated: false,
+        update() {
+            this.updated = true;
+        },
+    };
+    return block;
+}
+
+describe('mergePasteIntoHeading', () => {
+    it('merges first paragraph state into an atx heading and returns the rest', () => {
+        const heading = content('Title');
+        const states = [
+            { name: 'paragraph', text: 'Hello' },
+            { name: 'paragraph', text: 'World' },
+        ];
+
+        const remaining = mergePasteIntoHeading(
+            heading as any,
+            { blockName: 'atx-heading' } as any,
+            states as any,
+            { startOffset: 5, endOffset: 5 },
+        );
+
+        expect(heading.text).toBe('TitleHello');
+        expect(heading.updated).toBe(true);
+        expect(remaining).toEqual([{ name: 'paragraph', text: 'World' }]);
+    });
+
+    it('also merges into setext heading', () => {
+        const heading = content('Title');
+        const states = [
+            { name: 'paragraph', text: 'Hello' },
+            { name: 'paragraph', text: 'World' },
+        ];
+
+        const remaining = mergePasteIntoHeading(
+            heading as any,
+            { blockName: 'setext-heading' } as any,
+            states as any,
+            { startOffset: 5, endOffset: 5 },
+        );
+
+        expect(heading.text).toBe('TitleHello');
+        expect(remaining).toEqual([{ name: 'paragraph', text: 'World' }]);
+    });
+
+    it('honours an existing selection on the heading by collapsing the selected range first', () => {
+        const heading = content('Title XXX'); // user selected "XXX" before pasting
+        const states = [
+            { name: 'paragraph', text: 'Hello' },
+            { name: 'paragraph', text: 'World' },
+        ];
+
+        const remaining = mergePasteIntoHeading(
+            heading as any,
+            { blockName: 'atx-heading' } as any,
+            states as any,
+            { startOffset: 6, endOffset: 9 },
+        );
+
+        expect(heading.text).toBe('Title Hello');
+        expect(remaining).toEqual([{ name: 'paragraph', text: 'World' }]);
+    });
+
+    it('returns the original states unchanged when wrapper is not a heading', () => {
+        const para = content('Foo');
+        const states = [
+            { name: 'paragraph', text: 'A' },
+            { name: 'paragraph', text: 'B' },
+        ];
+
+        const remaining = mergePasteIntoHeading(
+            para as any,
+            { blockName: 'paragraph' } as any,
+            states as any,
+            { startOffset: 3, endOffset: 3 },
+        );
+
+        expect(para.text).toBe('Foo');
+        expect(para.updated).toBe(false);
+        expect(remaining).toBe(states);
+    });
+
+    it('returns the original states when first state is not a paragraph', () => {
+        const heading = content('Title');
+        const states = [
+            { name: 'code-block', text: 'console.log()' },
+            { name: 'paragraph', text: 'after' },
+        ];
+
+        const remaining = mergePasteIntoHeading(
+            heading as any,
+            { blockName: 'atx-heading' } as any,
+            states as any,
+            { startOffset: 5, endOffset: 5 },
+        );
+
+        expect(heading.text).toBe('Title');
+        expect(heading.updated).toBe(false);
+        expect(remaining).toBe(states);
+    });
+
+    it('returns an empty array when states is empty (no-op)', () => {
+        const heading = content('Title');
+
+        const remaining = mergePasteIntoHeading(
+            heading as any,
+            { blockName: 'atx-heading' } as any,
+            [],
+            { startOffset: 5, endOffset: 5 },
+        );
+
+        expect(heading.text).toBe('Title');
+        expect(remaining).toEqual([]);
+    });
+});

--- a/packages/core/src/clipboard/index.ts
+++ b/packages/core/src/clipboard/index.ts
@@ -618,7 +618,7 @@ class Clipboard {
                 const remaining = mergePasteIntoHeading(
                     anchorBlock,
                     wrapperBlock,
-                    states as any,
+                    states,
                     { startOffset: start.offset, endOffset: end.offset },
                 );
 
@@ -629,7 +629,7 @@ class Clipboard {
                 }
 
                 for (const state of remaining) {
-                    const newBlock = ScrollPage.loadBlock(state.name).create(muya, state as any);
+                    const newBlock = ScrollPage.loadBlock(state.name).create(muya, state);
                     wrapperBlock?.parent?.insertAfter(newBlock, wrapperBlock);
                     wrapperBlock = newBlock;
                 }

--- a/packages/core/src/clipboard/index.ts
+++ b/packages/core/src/clipboard/index.ts
@@ -13,7 +13,7 @@ import { MarkdownToState } from '../state/markdownToState';
 import StateToMarkdown from '../state/stateToMarkdown';
 import { deepClone } from '../utils';
 import { getClipBoardHtml } from '../utils/marked';
-import { getCopyTextType, normalizePastedHTML } from '../utils/paste';
+import { getCopyTextType, isStandaloneTableHtml, normalizePastedHTML } from '../utils/paste';
 import { mergePasteIntoHeading } from './mergePasteIntoHeading';
 
 class Clipboard {
@@ -575,6 +575,13 @@ class Clipboard {
         // Support pasted URLs from Firefox.
         if (URL_REG.test(text) && !/\s/.test(text) && !html)
             html = `<a href="${text}">${text}</a>`;
+
+        // Apple Numbers and a handful of other sources only put a raw
+        // `<table>...</table>` blob in text/plain. Promote it to the HTML
+        // slot so it goes through the HTML→Markdown converter rather than
+        // being inserted verbatim (marktext 067ec485 / #1271).
+        if (!html && isStandaloneTableHtml(text))
+            html = text;
 
         // Remove crap from HTML such as meta data and styles.
         html = await normalizePastedHTML(html);

--- a/packages/core/src/clipboard/index.ts
+++ b/packages/core/src/clipboard/index.ts
@@ -284,26 +284,37 @@ class Clipboard {
         if (!event.clipboardData)
             return;
 
+        // Mirror native copy behaviour: leave the system clipboard untouched
+        // when the selection has nothing to contribute, so a previous copy
+        // from another app isn't silently clobbered (marktext #3130).
         switch (copyType) {
             case 'normal': {
+                if (text.length === 0)
+                    return;
                 event.clipboardData.setData('text/html', html);
                 event.clipboardData.setData('text/plain', text);
                 break;
             }
 
             case 'copyAsHtml': {
+                if (html.length === 0)
+                    return;
                 event.clipboardData.setData('text/html', '');
                 event.clipboardData.setData('text/plain', html);
                 break;
             }
 
             case 'copyAsMarkdown': {
+                if (text.length === 0)
+                    return;
                 event.clipboardData.setData('text/html', '');
                 event.clipboardData.setData('text/plain', text);
                 break;
             }
 
             case 'copyCodeContent': {
+                if (text.length === 0)
+                    return;
                 event.clipboardData.setData('text/html', '');
                 event.clipboardData.setData('text/plain', text);
                 break;

--- a/packages/core/src/clipboard/index.ts
+++ b/packages/core/src/clipboard/index.ts
@@ -14,6 +14,7 @@ import StateToMarkdown from '../state/stateToMarkdown';
 import { deepClone } from '../utils';
 import { getClipBoardHtml } from '../utils/marked';
 import { getCopyTextType, normalizePastedHTML } from '../utils/paste';
+import { mergePasteIntoHeading } from './mergePasteIntoHeading';
 
 class Clipboard {
     public copyType: string = 'normal'; // `normal` or `copyAsMarkdown` or `copyAsHtml` or `copyCodeContent`
@@ -594,11 +595,6 @@ class Clipboard {
                 /\n\n/.test(markdown)
                 && anchorBlock.blockName !== 'codeblock.content'
             ) {
-                if (start.offset !== end.offset) {
-                    anchorBlock.text
-                        = content.substring(0, start.offset) + content.substring(end.offset);
-                    anchorBlock.update();
-                }
                 // Has multiple paragraphs.
                 const states = new MarkdownToState({
                     footnote,
@@ -608,8 +604,25 @@ class Clipboard {
                     frontMatter,
                 }).generate(markdown);
 
-                for (const state of states) {
-                    const newBlock = ScrollPage.loadBlock(state.name).create(muya, state);
+                // When pasting into a heading, splice the first paragraph
+                // back into the heading text so the heading semantics survive.
+                // The helper also collapses any selection on the heading.
+                // Backport of marktext 1c42555a (#671).
+                const remaining = mergePasteIntoHeading(
+                    anchorBlock,
+                    wrapperBlock,
+                    states as any,
+                    { startOffset: start.offset, endOffset: end.offset },
+                );
+
+                if (remaining === states && start.offset !== end.offset) {
+                    anchorBlock.text
+                        = content.substring(0, start.offset) + content.substring(end.offset);
+                    anchorBlock.update();
+                }
+
+                for (const state of remaining) {
+                    const newBlock = ScrollPage.loadBlock(state.name).create(muya, state as any);
                     wrapperBlock?.parent?.insertAfter(newBlock, wrapperBlock);
                     wrapperBlock = newBlock;
                 }

--- a/packages/core/src/clipboard/mergePasteIntoHeading.ts
+++ b/packages/core/src/clipboard/mergePasteIntoHeading.ts
@@ -1,12 +1,7 @@
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
+import type { TState } from '../state/types';
 import type { Nullable } from '../types';
-
-interface IPasteState {
-    name: string;
-    text?: string;
-    [key: string]: unknown;
-}
 
 interface IPasteCursor {
     startOffset: number;
@@ -26,9 +21,9 @@ interface IPasteCursor {
 export function mergePasteIntoHeading(
     anchorBlock: Content,
     wrapperBlock: Nullable<Pick<Parent, 'blockName'>>,
-    states: IPasteState[],
+    states: TState[],
     cursor: IPasteCursor,
-): IPasteState[] {
+): TState[] {
     if (states.length === 0)
         return states;
 
@@ -42,13 +37,12 @@ export function mergePasteIntoHeading(
     if (first.name !== 'paragraph')
         return states;
 
-    const inserted = typeof first.text === 'string' ? first.text : '';
     const original = anchorBlock.text;
     anchorBlock.text
         = original.substring(0, cursor.startOffset)
-            + inserted
+            + first.text
             + original.substring(cursor.endOffset);
-    (anchorBlock as unknown as { update: () => void }).update();
+    anchorBlock.update();
 
     return states.slice(1);
 }

--- a/packages/core/src/clipboard/mergePasteIntoHeading.ts
+++ b/packages/core/src/clipboard/mergePasteIntoHeading.ts
@@ -1,0 +1,54 @@
+import type Content from '../block/base/content';
+import type Parent from '../block/base/parent';
+import type { Nullable } from '../types';
+
+interface IPasteState {
+    name: string;
+    text?: string;
+    [key: string]: unknown;
+}
+
+interface IPasteCursor {
+    startOffset: number;
+    endOffset: number;
+}
+
+/**
+ * Backport of marktext commit 1c42555a (#671). When pasting multi-paragraph
+ * markdown into an atx/setext heading, splice the first paragraph state into
+ * the heading's text — keeping the heading semantics intact — and return the
+ * tail states so the caller can drop them in as new blocks below.
+ *
+ * When the wrapper is not a heading or the first state isn't a plain paragraph,
+ * the original states array is returned untouched and the caller falls back
+ * to its previous behaviour (which still needs to collapse any selection).
+ */
+export function mergePasteIntoHeading(
+    anchorBlock: Content,
+    wrapperBlock: Nullable<Pick<Parent, 'blockName'>>,
+    states: IPasteState[],
+    cursor: IPasteCursor,
+): IPasteState[] {
+    if (states.length === 0)
+        return states;
+
+    const isHeading
+        = wrapperBlock?.blockName === 'atx-heading'
+            || wrapperBlock?.blockName === 'setext-heading';
+    if (!isHeading)
+        return states;
+
+    const first = states[0];
+    if (first.name !== 'paragraph')
+        return states;
+
+    const inserted = typeof first.text === 'string' ? first.text : '';
+    const original = anchorBlock.text;
+    anchorBlock.text
+        = original.substring(0, cursor.startOffset)
+            + inserted
+            + original.substring(cursor.endOffset);
+    (anchorBlock as unknown as { update: () => void }).update();
+
+    return states.slice(1);
+}

--- a/packages/core/src/utils/__tests__/getCopyTextType.spec.ts
+++ b/packages/core/src/utils/__tests__/getCopyTextType.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { getCopyTextType, isStandaloneTableHtml } from '../paste';
+
+// Regression for marktext commit 067ec485 (#1271).
+// Some clipboard sources (e.g. Apple Numbers, certain spreadsheet
+// exporters) put a raw `<table>...</table>` blob in `text/plain` only,
+// with no `text/html` flavour. Old behaviour: classified as plain text,
+// so the HTML literal ended up inserted verbatim into a paragraph.
+// Fix: a sniffing helper that detects the lone-table shape; the paste
+// handler promotes such text into the html slot so it goes through the
+// HTML→Markdown table converter and a real markdown table comes out.
+
+describe('isStandaloneTableHtml', () => {
+    it('matches a single top-level <table>...</table>', () => {
+        expect(
+            isStandaloneTableHtml(
+                '<table><tr><td>a</td></tr></table>',
+            ),
+        ).toBe(true);
+    });
+
+    it('tolerates leading/trailing whitespace and attributes on the opener', () => {
+        expect(
+            isStandaloneTableHtml(
+                '  <table border="1"><tr><td>a</td></tr></table>\n',
+            ),
+        ).toBe(true);
+    });
+
+    it('rejects non-table HTML', () => {
+        expect(isStandaloneTableHtml('<span>hi</span>')).toBe(false);
+        expect(isStandaloneTableHtml('<p>hi</p>')).toBe(false);
+    });
+
+    it('rejects content with trailing text outside the table', () => {
+        expect(
+            isStandaloneTableHtml(
+                '<table><tr><td>a</td></tr></table> extra',
+            ),
+        ).toBe(false);
+    });
+
+    it('rejects plain text and empty strings', () => {
+        expect(isStandaloneTableHtml('plain string')).toBe(false);
+        expect(isStandaloneTableHtml('')).toBe(false);
+    });
+});
+
+describe('getCopyTextType — pre-existing classifier behaviour stays put', () => {
+    it('returns html when both html and text are present', () => {
+        expect(getCopyTextType('<p>x</p>', 'x', 'normal')).toBe('html');
+    });
+
+    it('returns code for <p> text-only', () => {
+        expect(getCopyTextType('', '<p>hi</p>', 'normal')).toBe('code');
+    });
+
+    it('returns text for non-paragraph HTML shape text', () => {
+        expect(getCopyTextType('', '<span>hi</span>', 'normal')).toBe('text');
+    });
+
+    it('falls back to text for plain strings', () => {
+        expect(getCopyTextType('', 'plain string', 'normal')).toBe('text');
+    });
+
+    it('pasteAsPlainText ignores html', () => {
+        expect(
+            getCopyTextType('<p>hi</p>', '<p>hi</p>', 'pasteAsPlainText'),
+        ).toBe('code');
+    });
+});

--- a/packages/core/src/utils/__tests__/getPageTitle.spec.ts
+++ b/packages/core/src/utils/__tests__/getPageTitle.spec.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Regression for marktext commit 141d25d8 (#1344).
+// `getPageTitle` is meant to fetch a URL, parse the `<title>` out of the
+// HTML body, and return it so a pasted bare URL renders as a link with
+// the page's real title. The current impl pipes the HTML body through
+// `res.json()`, which throws on every text/html response — so the
+// helper always swallows the error and returns ''. The fix uses
+// `res.text()`.
+
+function htmlResponse(html: string) {
+    return new Response(html, {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+    });
+}
+
+describe('getPageTitle — parses <title> from HTML', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.stubGlobal('navigator', { onLine: true, userAgent: 'node-test' });
+        fetchSpy = vi.fn();
+        vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+        vi.restoreAllMocks();
+    });
+
+    it('returns the <title> contents for an http(s) URL with a 200 text/html response', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            htmlResponse('<html><head><title>Example Domain</title></head><body>x</body></html>'),
+        );
+        const { getPageTitle } = await import('../paste');
+
+        const title = await getPageTitle('https://example.com/');
+
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        expect(title).toBe('Example Domain');
+    });
+
+    it('returns empty string when URL does not start with http', async () => {
+        const { getPageTitle } = await import('../paste');
+
+        const title = await getPageTitle('file:///etc/passwd');
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(title).toBe('');
+    });
+
+    it('returns empty string when offline', async () => {
+        vi.stubGlobal('navigator', { onLine: false, userAgent: 'node-test' });
+        const { getPageTitle } = await import('../paste');
+
+        const title = await getPageTitle('https://example.com/');
+
+        expect(fetchSpy).not.toHaveBeenCalled();
+        expect(title).toBe('');
+    });
+
+    it('returns empty string when the response is not text/html', async () => {
+        fetchSpy.mockResolvedValueOnce(
+            new Response('{"hi":1}', {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+            }),
+        );
+        const { getPageTitle } = await import('../paste');
+
+        const title = await getPageTitle('https://example.com/api');
+
+        expect(title).toBe('');
+    });
+
+    it('returns empty string on fetch error', async () => {
+        fetchSpy.mockRejectedValueOnce(new Error('network'));
+        const { getPageTitle } = await import('../paste');
+
+        const title = await getPageTitle('https://example.com/');
+
+        expect(title).toBe('');
+    });
+});

--- a/packages/core/src/utils/paste.ts
+++ b/packages/core/src/utils/paste.ts
@@ -112,6 +112,18 @@ export async function normalizePastedHTML(html: string) {
     return tempWrapper.innerHTML;
 }
 
+// Sniffs whether `text` is a single top-level `<table>...</table>` blob.
+// Some clipboard sources (notably Apple Numbers, marktext #1271) put raw
+// HTML into `text/plain` with no `text/html` flavour; the paste handler
+// promotes such text into the html slot so the table goes through the
+// HTML→Markdown converter instead of being inserted verbatim.
+const STANDALONE_TABLE_REG = /^<table\b[\s\S]*<\/table>$/i;
+export function isStandaloneTableHtml(text: string) {
+    if (!text)
+        return false;
+    return STANDALONE_TABLE_REG.test(text.trim());
+}
+
 /**
  *
  * @param {string} html

--- a/packages/core/src/utils/paste.ts
+++ b/packages/core/src/utils/paste.ts
@@ -18,18 +18,16 @@ export async function getPageTitle(url: string) {
         const res = await fetch(url, { method: 'GET', mode: 'cors' });
         const contentType = res.headers.get('content-type');
 
-        if (res.status === 200 && contentType && /text\/html/.test(contentType)) {
-            const response = await res.json();
-
-            if (typeof response === 'string') {
-                const match = response.match(/<title>(.*)<\/title>/);
-
-                return match && match[1] ? match[1] : '';
-            }
-
+        if (res.status !== 200 || !contentType || !/text\/html/.test(contentType))
             return '';
-        }
-        return '';
+
+        // The response is HTML — read it as text and pluck `<title>`.
+        // Pre-fix this called `res.json()`, which always threw and made
+        // the helper silently return '' (marktext 141d25d8 / #1344).
+        const body = await res.text();
+        const match = body.match(/<title>([\s\S]*?)<\/title>/i);
+
+        return match && match[1] ? match[1].trim() : '';
     }
     catch {
         return '';

--- a/packages/core/src/utils/paste.ts
+++ b/packages/core/src/utils/paste.ts
@@ -18,7 +18,7 @@ export async function getPageTitle(url: string) {
         const res = await fetch(url, { method: 'GET', mode: 'cors' });
         const contentType = res.headers.get('content-type');
 
-        if (res.status !== 200 || !contentType || !/text\/html/.test(contentType))
+        if (res.status !== 200 || !contentType || !/text\/html/i.test(contentType))
             return '';
 
         // The response is HTML — read it as text and pluck `<title>`.
@@ -112,11 +112,13 @@ export async function normalizePastedHTML(html: string) {
     return tempWrapper.innerHTML;
 }
 
-// Sniffs whether `text` is a single top-level `<table>...</table>` blob.
-// Some clipboard sources (notably Apple Numbers, marktext #1271) put raw
-// HTML into `text/plain` with no `text/html` flavour; the paste handler
-// promotes such text into the html slot so the table goes through the
-// HTML→Markdown converter instead of being inserted verbatim.
+// Sniffs whether `text` looks like an HTML `<table>` blob and nothing else
+// (no surrounding prose). The regex deliberately doesn't enforce "exactly
+// one root element" — sibling tables in the same payload still belong on
+// the HTML→Markdown path. Some clipboard sources (notably Apple Numbers,
+// marktext #1271) put raw HTML into `text/plain` with no `text/html`
+// flavour; the paste handler promotes such text into the html slot so it
+// goes through `HtmlToMarkdown` instead of being inserted verbatim.
 const STANDALONE_TABLE_REG = /^<table\b[\s\S]*<\/table>$/i;
 export function isStandaloneTableHtml(text: string) {
     if (!text)


### PR DESCRIPTION
## Summary

Backports the PR-4 marktext muya → @muyajs/core migration batch covering the clipboard / paste / copy path. Each fix lands as its own commit, written **red → green** per the migration discipline (failing test first, then the change to make it pass).

| marktext commit | issue | what changes | tests |
|---|---|---|---|
| `1c42555a` | #671 | Multi-line paste into a heading now merges the first paragraph into the heading text (extracted as `mergePasteIntoHeading` pure helper) instead of inserting all paragraphs below. | 6 |
| `067ec485` (partial) | #1271 | Text-only `<table>…</table>` blobs (Apple Numbers etc.) are promoted into the html slot so they go through `HtmlToMarkdown` and produce a real markdown table. New `isStandaloneTableHtml` sniffer. | 10 |
| `141d25d8` | #1344 | `getPageTitle` was calling `res.json()` on a text/html response, which always threw and made the helper silently return `''`. Use `res.text()` so pasted bare URLs actually pick up `<title>`. | 5 |
| `c841facd` | #3130 | `copyHandler` no longer writes to the clipboard when the relevant payload is empty — matches native behaviour so a previous copy from another app isn't clobbered. | 6 |

### Verified-not-applicable (defensive coverage where useful)

- `393139e5` — copy path is already escape-free; 2 guard tests pin the contract.
- `54a3b585` — `sanitize(html, …, false)` is already in place.
- `b925f7d6` — `cutHandler` already returns early on a null selection.
- `485fcfe0` — no image-paste path in the new architecture; the early-return guard is moot.
- `fb8fca7b` — turndown `paragraph` / `listItem` rules already live in `utils/turndownService`; the DOM checkbox-injection branch is marktext-DOM-specific.
- `c3f128e7` — same reasoning as `fb8fca7b` (new copy path renders via `marked`, not via the DOM).
- `ef59a743` — `copyHandler('normal')` already sets both `text/html` and `text/plain`.

### Left pending

- `5b1cd85d` "paste error when the last block is html block" — needs examples manual repro; the new-arch multi-paragraph insertion doesn't recurse into block children the way marktext's `getLastBlock` did, so the bug is structurally suspected gone, but I want a manual cross-browser check before claiming it.

## Test plan

- [x] `pnpm --filter @muyajs/core test` — 62 tests passing (8 new specs)
- [x] `pnpm lint:types` — clean
- [x] `pnpm check-circular` — no circular dependencies
- [ ] Manual cross-browser paste (Chrome + Safari) from Word / Notion / GitHub / VSCode against the examples app
- [ ] Manual repro check for `5b1cd85d` end-of-doc html-block paste

Migration tracking table in `MIGRATION.md` updated (PR-4a / PR-4b / PR-4c statuses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)