### PR TITLE
test: defensive inline regressions for bold+code, parens-in-dest (PR-2c)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -178,7 +178,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 |---|---|---|---|
 | PR-1a | 6 | 4 | 67%（2 fixed + 2 verified-not-applicable，2 转 PR-3） |
 | PR-1b | 7 | 6 | 86%（1 fixed + 4 verified-not-applicable + 1 skipped；防御测试 15 个） |
-| PR-2 | 26 | 15 | 58%（PR-2a 8 commits + PR-2b 3 commits + PR-2c 1 commit：2 fixed bugs + 11 test-only + 3 skipped；3 条转 PR-3/PR-4；新增 57af8304 入册）|
+| PR-2 | 26 | 15 | 58%（PR-2a 8 commits = 2 fixed bugs + 9 test-only；PR-2b 3 commits = 1 fixed bug + 2 test-only；PR-2c 1 commit = 2 test-only + 3 skipped；3 条转 PR-3/PR-4；新增 57af8304 入册）|
 | PR-3a | 5 | 5 | 100%（4 verified-not-applicable + 1 test-only；防御测试 2 个 soft-line） |
 | PR-3b | 4 | 4 | 100%（1 fixed `358fa83d` + 3 verified-not-applicable；回归测试 13 个） |
 | PR-3c | 3 | 3 | 100%（3 verified-not-applicable；+1 compositionend 防御测试；跨 block+IME 留 examples/ 手测） |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -57,9 +57,10 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 5f191681 | parser | blockquote 内 list（exportMarkdown） | PR-2b | `pending`（同上） |
 | 70d49c30 | parser | `-foo` 误识 list item | PR-2a | `test-only`（marked v16 已要求 bullet 后接空格；2 个正负回归测试） |
 | 7b7a9424 | math | math block 嵌套 | PR-3 | `pending`（marktext fix 在 `paragraphCtrl.js` 编辑器层；PR-3 范围） |
-| d937fac0 | inline | inline 语法 | PR-2 | `pending` |
-| 9c2f6cb3 | inline | inline math 样式 | PR-2 | `pending` |
-| 6dfa7938 | inline | inline math selection | PR-2 | `pending` |
+| d937fac0 | inline | inline 语法 (#1071 重复 `**\`x\`**` 只末尾加粗) | PR-2c | `test-only`（`lowerPriority` 的 `ignoreIndex` 已就位；2 个回归测试） |
+| 57af8304 | inline | link/image dest 含括号 (#1169) | PR-2c | `test-only`（`correctUrl` 用 `findClosingBracket` 已就位；3 个回归测试） |
+| 9c2f6cb3 | inline | inline math 样式 | — | `skipped`（CSS-only，新仓样式体系自有 inline math 样式） |
+| 6dfa7938 | inline | inline math selection | — | `skipped`（CSS-only，新仓样式体系自有 selection 样式） |
 | d9f64bab | inline | reference link 渲染 | PR-2a | `test-only`（lexer.ts:357 `labels.has(...)` 已就位；2 个回归测试） |
 | b8e2cd82 | inline | inline html renderer | PR-3 | `pending`（textRenderer 改动主要在 muya HTML 导出；与 stateToMarkdown 关系待评估） |
 | 962fdf35 | inline | heading emoji 偏移 | — | `skipped`（CSS-only，新仓样式体系自有 emoji 处理） |
@@ -176,7 +177,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 |---|---|---|---|
 | PR-1a | 6 | 4 | 67%（2 fixed + 2 verified-not-applicable，2 转 PR-3） |
 | PR-1b | 7 | 6 | 86%（1 fixed + 4 verified-not-applicable + 1 skipped；防御测试 15 个） |
-| PR-2 | 25 | 11 | 44%（PR-2a: 2 fixed + 9 test-only；3 条转 PR-3/PR-4；1 skipped；2 留待 PR-2b 序列化基线）|
+| PR-2 | 26 | 15 | 58%（PR-2a 8 commits + PR-2b 3 commits + PR-2c：2 fixed bugs + 11 test-only + 3 skipped；3 条转 PR-3/PR-4；新增 57af8304 入册）|
 | PR-3a | 5 | 5 | 100%（4 verified-not-applicable + 1 test-only；防御测试 2 个 soft-line） |
 | PR-3b | 4 | 4 | 100%（1 fixed `358fa83d` + 3 verified-not-applicable；回归测试 13 个） |
 | PR-3c | 3 | 3 | 100%（3 verified-not-applicable；+1 compositionend 防御测试；跨 block+IME 留 examples/ 手测） |

--- a/packages/core/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
+++ b/packages/core/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
@@ -181,3 +181,64 @@ describe('inline lexer — GFM link/image title (marktext ad5ddbf9)', () => {
         expect(link.title).toBe('');
     });
 });
+
+// Defensive regression for marktext commit d937fac0 (issue #1071, PR #1072):
+// a sequence like `**\`word 1\`**, **\`word 2\`**` used to only bold the LAST
+// instance — every earlier `**` pair was emitted as literal text. The legacy
+// `lowerPriority` walked every position in the candidate span without
+// remembering which characters were already consumed by an earlier matching
+// rule, so an inline_code span ending mid-span fooled the strong rule into
+// thinking another rule extended past the closer. The fix tracked already-
+// consumed positions in an `ignoreIndex` array. The new muya's lowerPriority
+// (`inlineRenderer/utils.ts`) already has the same `ignoreIndex`, so this
+// lock-in protects against a future regression.
+describe('inline lexer — repeated bold + inline_code (marktext d937fac0 / #1071)', () => {
+    it('emits a strong token for EVERY `**`-wrapped code span in a sequence', () => {
+        const tokens = tokenizer('**`word 1`**, **`word 2`**, **`word 3`**');
+        const strongs = tokens.filter(t => t.type === 'strong');
+        expect(strongs.length, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBe(3);
+        // And each strong must contain a code span, not literal text.
+        for (const strong of strongs) {
+            const innerTypes = (strong as any).children.map((c: any) => c.type);
+            expect(innerTypes).toContain('inline_code');
+        }
+    });
+
+    it('does not flip the bug to em (single `*` + code) either', () => {
+        const tokens = tokenizer('*`word 1`*, *`word 2`*, *`word 3`*');
+        const ems = tokens.filter(t => t.type === 'em');
+        expect(ems.length, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBe(3);
+    });
+});
+
+// Defensive regression for marktext commit 57af8304 (issue #1169, PR #1170):
+// link / image destinations containing parens used to consume too much,
+// eating past the real closing `)`. The fix calls `findClosingBracket` to
+// pick the matching `)` and rewrites the captured groups so `\` escapes
+// land in the right slot. The new muya's `correctUrl` (utils.ts) ports the
+// same algorithm.
+describe('inline lexer — link / image dest with parens (marktext 57af8304 / #1169)', () => {
+    it('parses image dest containing balanced parens correctly', () => {
+        const tokens = tokenizer('![alt](path/to/(file).png)');
+        const image = tokens.find(t => t.type === 'image') as any;
+        expect(image, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
+        expect(image.src).toBe('path/to/(file).png');
+    });
+
+    it('parses link dest containing balanced parens correctly', () => {
+        const tokens = tokenizer('[text](path/to/(file).html)');
+        const link = tokens.find(t => t.type === 'link') as any;
+        expect(link, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
+        expect(link.href).toBe('path/to/(file).html');
+    });
+
+    it('stops at the matching `)` even when more chars follow on the line', () => {
+        const tokens = tokenizer('text before ![alt](x.png) text after');
+        const image = tokens.find(t => t.type === 'image') as any;
+        expect(image).toBeDefined();
+        expect(image.src).toBe('x.png');
+        // The trailing "text after" must remain as text, not be eaten.
+        const joined = tokens.map(t => (t as any).raw ?? '').join('');
+        expect(joined).toContain('text after');
+    });
+});

--- a/packages/core/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
+++ b/packages/core/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
@@ -232,13 +232,20 @@ describe('inline lexer — link / image dest with parens (marktext 57af8304 / #1
         expect(link.href).toBe('path/to/(file).html');
     });
 
-    it('stops at the matching `)` even when more chars follow on the line', () => {
-        const tokens = tokenizer('text before ![alt](x.png) text after');
+    it('stops at the FIRST matching `)` when more `)` appear later on the line', () => {
+        // This is the real shape of the marktext regression: greedy `(.*)` in
+        // the image regexp would gobble all the way to the LAST `)`, swallowing
+        // both `first.png` and the `(parens)` text. `correctUrl` /
+        // `findClosingBracket` walks the destination to the matching `)` so
+        // the image stops at `first.png` and the rest stays as following text.
+        const tokens = tokenizer('see ![alt](first.png) and also (parens) here');
         const image = tokens.find(t => t.type === 'image') as any;
-        expect(image).toBeDefined();
-        expect(image.src).toBe('x.png');
-        // The trailing "text after" must remain as text, not be eaten.
+        expect(image, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
+        expect(image.src).toBe('first.png');
+        // The trailing text — including the unrelated `(parens)` group — must
+        // remain outside the image token.
         const joined = tokens.map(t => (t as any).raw ?? '').join('');
-        expect(joined).toContain('text after');
+        expect(joined).toContain('and also (parens) here');
+        expect(image.raw).not.toContain('parens');
     });
 });


### PR DESCRIPTION
## Summary

PR-2c of the marktext-muya → @muyajs/core migration. One commit, two
defensive-regression clusters for the inline lexer.

The original PR-2 plan listed three remaining `PR-2 pending` items
after PR-2a/2b: `d937fac0`, `9c2f6cb3`, `6dfa7938`. Two of the three
turned out to be CSS-only (`9c2f6cb3` inline math style, `6dfa7938`
inline math selection) — the new muya owns its style system, so the
old fixes don't apply. `MIGRATION.md` routes both to `skipped`.

The remaining bug fix is already implemented in the new muya, so the
PR is test-only.

### Defensive regressions (test-only)

| marktext commit | scope | specs |
|---|---|---|
| d937fac0 (#1071) | sequence `**\`word 1\`**, **\`word 2\`**, ...` must emit a strong-with-inline_code for every entry, not just the last | 2 |
| 57af8304 (#1169) | link / image dest containing balanced parens stops at the right `)` and leaves following text intact | 3 |

`57af8304` wasn't in the original P1 plan list — found while reviewing
the inline lexer history. It's now catalogued as a new P1 row in
MIGRATION.md so PR-6 (spec compliance) has the full picture.

## Test plan

- [x] `pnpm --filter @muyajs/core test` — 132 specs pass (5 new in this PR)
- [x] `pnpm --filter @muyajs/core lint:types` — clean
- [x] `pnpm check-circular` — no circular deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)