### PR TITLE
fix: cleanup PR-7a — list/paragraph/clipboard 4-pack (verified-not-applicable + defensive tests)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,10 +49,10 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 57cd04c5 | parser | CommonMark example 475 + 353/387/520/521 等 | PR-2a | `fixed`（canOpenEmphasis 阻断 mid-run `_`；link/reference_link 加 lowerPriority；5 个 CM spec 用例） |
 | ad5ddbf9 | parser | GFM example 558（link/image title 支持） | PR-2a | `test-only`（`parseSrcAndTitle` 已就位；4 个回归测试锁定 link/image title） |
 | 372fe02f | parser | list 解析 #870（task + bullet 混排拆分） | PR-2a | `test-only`（`compatibleTaskList` 已就位；1 个回归测试） |
-| 8891287b | parser | paragraph → list 转换 | PR-3 | `pending`（marktext fix 在 `updateCtrl.js` 编辑器键盘逻辑层；PR-2 范围外） |
+| 8891287b | parser | paragraph → list 转换 | PR-7a | `verified-not-applicable`：marktext fix 是 `updateCtrl.updateParagraphToList` 的 line-splitting 旧逻辑（无 marker 时 listItemLines 为空 → text 丢失）。新仓 `replaceBlockByLabel({label:'bullet-list', text})` 直接 `state.children[0].children[0].text = text` 整段保留，无 LIST_ITEM_REG 分行。**新增 6 个回归测试**锁住 contract |
 | 270d33f6 | parser | list item lexer/parser（CM 264/265 不同 marker 拆表） | PR-2a | `test-only`（marked v16 + `compatibleTaskList` 已就位；2 个 CM spec 测试） |
-| 04834032 | parser | tab 缩进 list | PR-3 | `pending`（marktext fix 在 `tabCtrl.js` 编辑器 keydown 逻辑；PR-2 范围外） |
-| 240d64aa | parser | 合并不同类型 list #706 | PR-4 | `pending`（marktext fix 在 `pasteCtrl.js` 粘贴流程；PR-4 clipboard 系列处理） |
+| 04834032 | parser | tab 缩进 list | PR-7a | `verified-not-applicable`：commit title 误导，实际修的是 markup code-block 内 Tab → Emmet HTML 展开（`parseSelector(undefined)` 崩 + `lastWord` 未限定到光标前 + postText 丢失）。新仓 `codeBlockContent.tabHandler` 已含 `lastWordBeforeCursor` + `postText` + `parseSelector(str='')` 三重修复。**新增 5 个回归测试**（含 mid-text、empty、non-markup 分支） |
+| 240d64aa | parser | 合并不同类型 list #706 | PR-7a | `verified-not-applicable`：marktext bug 在 `pasteCtrl` 合并 list-items 进现存 list 时未对齐 looseness。新仓 `pasteHandler` (`clipboard/index.ts:631-635`) 走 `for (state of remaining) ScrollPage.loadBlock(state.name).create(...) + insertAfter`，**每个粘贴状态独立成块**，不会与既存 list 合并，结构上不存在 looseness 错配 |
 | 02841ffd | parser | list 后续段落归属（exportMarkdown 缩进配置） | PR-2b | `test-only`（stateToMarkdown 已实现 indent/listIndent 拆分；4 个 marktext 缩进 fixture + 4 个扩展 round-trip） |
 | 5f191681 | parser | blockquote 内 list（exportMarkdown） | PR-2b | `test-only`（3 个 blockquote round-trip 测试） |
 | insertLineBreak 行尾空格 | serializer | 列表项内空行带尾随空格 | PR-2b | `fixed`（`insertLineBreak` 去掉尾随空格，保留 `>` 前缀；1 个回归测试） |
@@ -87,7 +87,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 0dc4b415 | table | cell backspace | PR-3d | `test-only`（`<br/>X` 末尾 backspace 旧路径在 contentState 内被特化；新仓走 `Format.backspaceHandler` token-based + 浏览器原生删除；建议 examples/ 手测 `<br/>` 后字符删除） |
 | 5fb130d9 | table | shift+tab 表格导航 | PR-3d | `fixed`（`tableCell.tabHandler` 新增 `event.shiftKey` 分支 + `previousContentInContext()`；3 个回归测试） |
 | 9e32c4a0 | table | cursor → next cell index 0 | PR-3d | `verified-not-applicable`（`tableCell.tabHandler` 已 `setCursor(0, 0, true)`，不会选中整 cell 文本） |
-| 0028a4bc | table | cell copy 异常 | PR-4 | `pending`（涉及 clipboard / 表格 cell copy，归 PR-4） |
+| 0028a4bc | table | cell copy 异常 | PR-7a | `verified-not-applicable`：marktext fix 是 `paragraphCtrl.selectTableCells` 单 cell descriptor 缺 `text` 字段。新仓无 selected-cells descriptor —— `getClipboardData` 同块分支直读 `anchorBlock.text.substring(begin, end)`（`clipboard/index.ts:133`）。**新增 3 个回归测试**锁住 table.cell.content 单块 copy 路径 |
 | 3fa8a9ae | autopair | inline code 内禁用 | PR-3b | `verified-not-applicable`（`content.ts:autoPair` 已有 `isInInlineCode` 参数 + `format.ts` 调用前用 `_checkCursorInTokenType` 计算；defensive 测试 2 个） |
 | 4278362f | autopair | inline math 内禁用 | PR-3b | `verified-not-applicable`（同上，`isInInlineMath` 参数已就位；defensive 测试 1 个） |
 | bbea7eca | autopair | 优化自动补全 | PR-3b | `verified-not-applicable`（`!/[a-z0-9]/i.test(preInputChar)` 已在 markdown-syntax 分支；defensive 测试 3 个） |

--- a/packages/core/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
+++ b/packages/core/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import CodeBlockContent from '../index';
+
+// Regression for marktext 04834032 "fix list indent by tab (#908)".
+// Despite the misleading commit title, the fix is actually about the
+// Emmet-style HTML tag expansion that fires when Tab is pressed inside
+// a markup / html / xml / svg / mathml code block.
+//
+// The pre-fix logic:
+//   - used the trailing word of the entire line (`text.split(/\s+/).pop()`)
+//     instead of the word immediately preceding the cursor;
+//   - dropped everything after the cursor when emitting the new HTML;
+//   - called `parseSelector(undefined)` when the line was empty.
+//
+// Post-fix logic (current `codeBlockContent.tabHandler`):
+//   - reads `lastWordBeforeCursor = text.substring(0, start.offset).split(/\s+/).pop()`;
+//   - composes `preText + html + postText` so trailing content survives;
+//   - `parseSelector` defaults to `''` so it never blows up on undefined.
+//
+// We drive the prototype directly with a structurally typed `this` so we
+// don't need a real Muya bootstrap.
+
+interface FakeCell {
+    text: string;
+    lang: string;
+    cursor: { start: number; end: number };
+    getCursor: () => { start: { offset: number }; end: { offset: number } };
+    setCursor: (start: number, end: number, _selected?: boolean) => void;
+    insertTab: () => void;
+}
+
+function makeFakeCodeContent(initial: {
+    text: string;
+    lang: string;
+    cursorAt: number;
+}): FakeCell {
+    return {
+        text: initial.text,
+        lang: initial.lang,
+        cursor: { start: initial.cursorAt, end: initial.cursorAt },
+        getCursor() {
+            return {
+                start: { offset: this.cursor.start },
+                end: { offset: this.cursor.end },
+            };
+        },
+        setCursor(start: number, end: number) {
+            this.cursor = { start, end };
+        },
+        insertTab: vi.fn(),
+    };
+}
+
+function makeKeyEvent() {
+    return {
+        preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+}
+
+describe('codeBlockContent.tabHandler — 04834032 Emmet expansion preserves postText', () => {
+    it('expands selector and keeps the text after the cursor intact', () => {
+        // Cursor sits right after `div` but more text follows.
+        const cell = makeFakeCodeContent({
+            text: 'div post-text',
+            lang: 'html',
+            cursorAt: 3,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        // Pre-fix bug: line became `<div></div>` and ` post-text` was lost.
+        // Post-fix expectation: trailing content survives.
+        expect(cell.text).toBe('<div></div> post-text');
+        expect(cell.text.includes('post-text')).toBe(true);
+    });
+
+    it('expands `div#id.cls` mid-line without dropping the suffix', () => {
+        const cell = makeFakeCodeContent({
+            text: 'div#main.box trailing',
+            lang: 'html',
+            cursorAt: 'div#main.box'.length,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        // The id="main" / class="box" expansion must remain anchored;
+        // the trailing word must survive.
+        expect(cell.text).toMatch(/^<div id="main" class="box"><\/div>/);
+        expect(cell.text.endsWith(' trailing')).toBe(true);
+    });
+
+    it('does not throw when called on an empty line (parseSelector default arg)', () => {
+        const cell = makeFakeCodeContent({
+            text: '',
+            lang: 'html',
+            cursorAt: 0,
+        });
+
+        expect(() => {
+            CodeBlockContent.prototype.tabHandler.call(
+                cell as unknown as CodeBlockContent,
+                makeKeyEvent(),
+            );
+        }).not.toThrow();
+    });
+
+    it('falls back to insertTab when no valid selector precedes the cursor in markup', () => {
+        const cell = makeFakeCodeContent({
+            text: 'not-a-tag ',
+            lang: 'html',
+            cursorAt: 'not-a-tag '.length,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        // `lastWordBeforeCursor` is the empty string after the trailing space →
+        // parseSelector → no tag → insertTab.
+        expect(cell.insertTab).toHaveBeenCalledTimes(1);
+        expect(cell.text).toBe('not-a-tag ');
+    });
+
+    it('falls back to insertTab for non-markup languages', () => {
+        const cell = makeFakeCodeContent({
+            text: 'div',
+            lang: 'javascript',
+            cursorAt: 3,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        expect(cell.insertTab).toHaveBeenCalledTimes(1);
+        expect(cell.text).toBe('div');
+    });
+});

--- a/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -61,3 +61,48 @@ describe('clipboard.getClipboardData — single-block selection is not HTML-esca
         expect(text).toBe('');
     });
 });
+
+// Regression for marktext commit 0028a4bc (#2375 — "Fix issue with not being
+// able to copy table cell"). marktext's old `paragraphCtrl.selectTableCells`
+// built a virtual {key, top, right, bottom, left, ...} cell descriptor for
+// single-cell copy, but forgot the `text` field; the descriptor went to the
+// clipboard with an empty body, so copying a cell produced "".
+//
+// New muya's `getClipboardData` doesn't have a separate "selected table
+// cell" data structure: when the user copies inside a single
+// `table.cell.content` block, the `isSelectionInSameBlock` branch simply
+// reads `anchorBlock.text.substring(begin, end)`. So the text always survives
+// — provided the call site still feeds the cell's text into that substring.
+// This defensive test pins that contract.
+describe('clipboard.getClipboardData — single table-cell copy keeps the cell text (marktext 0028a4bc)', () => {
+    it('copies the full cell text when the user selects everything in the cell', () => {
+        const cellText = 'cell <body> & "value"';
+        const clipboard = makeClipboard(cellText, 0, cellText.length);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe(cellText);
+        expect(text).not.toBe('');
+    });
+
+    it('copies a partial selection inside the cell verbatim', () => {
+        // Selecting `<body>` out of the middle of a cell — the substring
+        // must not be HTML-escaped or stripped.
+        const cellText = 'pre <body> post';
+        const clipboard = makeClipboard(cellText, 4, 10);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe('<body>');
+    });
+
+    it('returns the cell text even when it is the only content', () => {
+        // The original marktext bug: descriptor had no `text` → output "".
+        // Here we assert the path that fills it.
+        const clipboard = makeClipboard('only-cell', 0, 9);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe('only-cell');
+    });
+});

--- a/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -25,20 +25,32 @@ function fakeMuya() {
     } as unknown as Muya;
 }
 
-function selectionOver(text: string, begin: number, end: number) {
+function selectionOver(
+    text: string,
+    begin: number,
+    end: number,
+    blockName: string = 'paragraph.content',
+) {
     return {
         isSelectionInSameBlock: true,
         anchor: { offset: begin },
         focus: { offset: end },
-        anchorBlock: { text } as any,
-        focusBlock: { text } as any,
+        anchorBlock: { text, blockName } as any,
+        focusBlock: { text, blockName } as any,
     };
 }
 
-function makeClipboard(text: string, begin: number, end: number) {
+function makeClipboard(
+    text: string,
+    begin: number,
+    end: number,
+    blockName?: string,
+) {
     const clipboard = new Clipboard(fakeMuya());
     Object.defineProperty(clipboard, 'selection', {
-        get: () => ({ getSelection: () => selectionOver(text, begin, end) }),
+        get: () => ({
+            getSelection: () => selectionOver(text, begin, end, blockName),
+        }),
     });
     Object.defineProperty(clipboard, 'scrollPage', { get: () => null });
     return clipboard;
@@ -77,7 +89,12 @@ describe('clipboard.getClipboardData — single-block selection is not HTML-esca
 describe('clipboard.getClipboardData — single table-cell copy keeps the cell text (marktext 0028a4bc)', () => {
     it('copies the full cell text when the user selects everything in the cell', () => {
         const cellText = 'cell <body> & "value"';
-        const clipboard = makeClipboard(cellText, 0, cellText.length);
+        const clipboard = makeClipboard(
+            cellText,
+            0,
+            cellText.length,
+            'table.cell.content',
+        );
 
         const { text } = clipboard.getClipboardData();
 
@@ -89,7 +106,7 @@ describe('clipboard.getClipboardData — single table-cell copy keeps the cell t
         // Selecting `<body>` out of the middle of a cell — the substring
         // must not be HTML-escaped or stripped.
         const cellText = 'pre <body> post';
-        const clipboard = makeClipboard(cellText, 4, 10);
+        const clipboard = makeClipboard(cellText, 4, 10, 'table.cell.content');
 
         const { text } = clipboard.getClipboardData();
 
@@ -99,7 +116,7 @@ describe('clipboard.getClipboardData — single table-cell copy keeps the cell t
     it('returns the cell text even when it is the only content', () => {
         // The original marktext bug: descriptor had no `text` → output "".
         // Here we assert the path that fills it.
-        const clipboard = makeClipboard('only-cell', 0, 9);
+        const clipboard = makeClipboard('only-cell', 0, 9, 'table.cell.content');
 
         const { text } = clipboard.getClipboardData();
 

--- a/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
+++ b/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
@@ -1,0 +1,216 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { ScrollPage } from '../../../block/scrollPage';
+import { replaceBlockByLabel } from '../config';
+
+// Regression for marktext 8891287b "fix paragraph turn into list bug (#1025)".
+//
+// In marktext, the old `updateCtrl.updateParagraphToList` ran a loop on
+// `text.split('\n')` looking for `LIST_ITEM_REG.test(l)` matches and dropped
+// every line that didn't match into `preParagraphLines`. When the conversion
+// was triggered from the front menu (no `marker` argument), no line ever
+// matched the bullet/order regex, so the entire paragraph contents were
+// silently lost.
+//
+// The marktext fix branched: `if (marker) { …split-and-strip… } else
+// { listItemLines = lines /* take the whole input verbatim */ }`.
+//
+// The new architecture has no `updateParagraphToList` at all — front-menu
+// conversion is `replaceBlockByLabel({label: 'bullet-list', text})`, which
+// builds the new list from `deepClone(emptyStates['bullet-list'])` and assigns
+// the whole `text` to `state.children[0].children[0].text` (a single
+// list-item's paragraph). No line splitting, no marker regex.
+//
+// We unit-test `replaceBlockByLabel` by stubbing `ScrollPage.loadBlock(...).create`
+// so we can capture the state object it builds, then assert that the text
+// the user typed survives verbatim.
+
+interface ICapturedCreate {
+    label: string;
+    state: any;
+}
+
+function setupCreateSpy(): {
+    captured: ICapturedCreate[];
+    restore: () => void;
+} {
+    const captured: ICapturedCreate[] = [];
+    const realLoadBlock = ScrollPage.loadBlock.bind(ScrollPage);
+    const spy = vi.spyOn(ScrollPage, 'loadBlock').mockImplementation((label: string) => {
+        return {
+            create: (_muya: any, state: any) => {
+                captured.push({ label, state });
+                // Return a fake block with the surface `replaceBlockByLabel`
+                // touches afterwards (`replaceWith` / `firstContentInDescendant`).
+                return makeFakeBlock(state);
+            },
+        } as any;
+    });
+
+    return {
+        captured,
+        restore: () => {
+            spy.mockRestore();
+            // The mock above does not call the real `loadBlock`, but reset for safety.
+            void realLoadBlock;
+        },
+    };
+}
+
+function makeFakeBlock(state: any): any {
+    const fake: any = {
+        state,
+        parent: { insertAfter: vi.fn() },
+        replaceWith: vi.fn(),
+        firstContentInDescendant: () => ({
+            text: '',
+            setCursor: vi.fn(),
+        }),
+    };
+    return fake;
+}
+
+function makeFakeOriginBlock(): any {
+    return {
+        replaceWith: vi.fn(),
+    };
+}
+
+function makeFakeMuya(): any {
+    return {
+        options: {
+            preferLooseListItem: false,
+            bulletListMarker: '-',
+            orderListDelimiter: '.',
+            frontmatterType: '---',
+        },
+    };
+}
+
+describe('replaceBlockByLabel — paragraph→list keeps text verbatim (marktext 8891287b)', () => {
+    it('bullet-list: puts plain paragraph text into the first list-item paragraph', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'bullet-list',
+                text: 'plain text',
+            });
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list).toBeTruthy();
+            expect(list.state.name).toBe('bullet-list');
+            expect(list.state.children).toHaveLength(1);
+            expect(list.state.children[0].name).toBe('list-item');
+            expect(list.state.children[0].children[0].name).toBe('paragraph');
+            expect(list.state.children[0].children[0].text).toBe('plain text');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('does not strip a leading `- ` from the bullet-list text (no marker regex)', () => {
+        // Pre-fix marktext (front-menu trigger, no marker) dropped this entire
+        // text since no line matched the bullet regex while `isPushedListItemLine`
+        // stayed false. New muya must keep it verbatim.
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'bullet-list',
+                text: '- foo',
+            });
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list.state.children[0].children[0].text).toBe('- foo');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('order-list: does not strip a leading `1. ` from the text', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'order-list',
+                text: '1. foo',
+            });
+
+            const list = captured.find(c => c.label === 'order-list')!;
+            expect(list.state.children[0].children[0].text).toBe('1. foo');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('keeps multi-line text in a single list-item paragraph (no split)', () => {
+        // Pre-fix marktext walked `text.split("\n")` and partitioned lines
+        // into preParagraphLines vs listItemLines. New muya never splits —
+        // the whole string goes into one paragraph.
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'bullet-list',
+                text: 'first line\nsecond line\nthird',
+            });
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list.state.children).toHaveLength(1);
+            expect(list.state.children[0].children[0].text).toBe(
+                'first line\nsecond line\nthird',
+            );
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('task-list: first item has the checkbox meta and the input text', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'task-list',
+                text: 'todo item',
+            });
+
+            const list = captured.find(c => c.label === 'task-list')!;
+            expect(list.state.children[0].name).toBe('task-list-item');
+            expect(list.state.children[0].meta).toEqual({ checked: false });
+            expect(list.state.children[0].children[0].text).toBe('todo item');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('empty text is acceptable (no exception, default empty paragraph)', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            expect(() => {
+                replaceBlockByLabel({
+                    block: makeFakeOriginBlock(),
+                    muya: makeFakeMuya(),
+                    label: 'bullet-list',
+                    text: '',
+                });
+            }).not.toThrow();
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list.state.children[0].children[0].text).toBe('');
+        }
+        finally {
+            restore();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

PR-7 series cleanup, batch A (4 marktext commits). All four turn out to be `verified-not-applicable` in the new architecture; this PR adds 14 defensive regression tests across the surface areas marktext fixed, locking the structural properties that make the bugs unreachable.

| Marktext commit | Title | Status | Tests added |
|---|---|---|---|
| [04834032](https://github.com/marktext/marktext/commit/04834032) | "fix list indent by tab" (#908) — actually Emmet expansion | verified-not-applicable | 5 |
| [8891287b](https://github.com/marktext/marktext/commit/8891287b) | paragraph→list bug (#1025) | verified-not-applicable | 6 |
| [240d64aa](https://github.com/marktext/marktext/commit/240d64aa) | combine lists of different type (#706) | verified-not-applicable | 0 (structural, see below) |
| [0028a4bc](https://github.com/marktext/marktext/commit/0028a4bc) | table cell copy (#2375) | verified-not-applicable | 3 |

### Root-cause summary per commit

- **04834032** — Commit title was misleading; the actual fix is for Emmet-style HTML tag expansion on Tab in markup code blocks. New repo already has the three fixes (parseSelector default arg, `lastWordBeforeCursor`, `postText` preservation) at `codeBlockContent/index.ts:252-262`. red→green verified by reverting to pre-fix state — 2 of 5 tests caught the regression.
- **8891287b** — marktext's `updateCtrl.updateParagraphToList` ran a `LIST_ITEM_REG` line-split that lost paragraph text when triggered from the front menu (no marker). New repo's `replaceBlockByLabel` just sets `state.children[0].children[0].text = text` on `deepClone(emptyStates[label])` — no line splitting. red→green verified by injecting marktext's pre-fix marker-strip — 3 of 6 tests caught it.
- **240d64aa** — marktext's `pasteCtrl` merged pasted list items into an existing list, mismatching `isLooseListItem`. New repo's `pasteHandler` (`clipboard/index.ts:631-635`) inserts each pasted state as its own block via `insertAfter(wrapperBlock)` — never merges items into a parent list. Structurally impossible to regress without rewriting pasteHandler from scratch; no new test required.
- **0028a4bc** — marktext's `paragraphCtrl.selectTableCells` built a single-cell descriptor missing the `text` field. New repo has no selected-cells descriptor: `getClipboardData`'s `isSelectionInSameBlock` branch reads `anchorBlock.text.substring(begin, end)` directly (`clipboard/index.ts:133`).

## Test plan
- [x] `pnpm --filter @muyajs/core test` (200 passed, was 159 baseline → +41 across PR-7)
- [x] `pnpm --filter @muyajs/core lint:types` clean
- [x] `pnpm check-circular` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)