### PR TITLE
fix: cleanup PR-7b — nested block boundaries 4-pack (1 fix + 3 verified-not-applicable)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,8 +36,8 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | c47795e4 | xss | XSS + Electron（部分电子相关跳过） | PR-1b | `skipped`（Electron-only） |
 | 0baf2e9e / 7de33f11 | xss | #1390 XSS | PR-1b | `pending`（issue 已关闭，影响面待评估；暂不实修） |
 | sanitizeHyperlink 防御 | xss | 锁住 `javascript:/vbscript:/data:` 阻断 | PR-1b | `test-only`（8 个防御测试） |
-| 6293d408 | table-ctrl | 老 tableBlockCtrl 修复，新仓无同名结构 | 待评估 | `pending`（建议 PR-3 验证） |
-| f99addd2 | table-ctrl | selectedTableCells 清理，新仓无对应 | 待评估 | `pending`（建议 PR-3 验证） |
+| 6293d408 | table-ctrl | 老 tableBlockCtrl 删行/列后光标修复 (#572) | PR-7b | `fixed`：`Table.removeRow/removeColumn` 现返回相邻 cell 的 firstChild，`tableRowColumMenu.selectItem` 拿到 cursorBlock 后 `setCursor(0, 0)`。**新增 8 个回归测试**覆盖中间删/末尾删/整表删/越界 4 个分支 |
+| f99addd2 | table-ctrl | selectedTableCells 清理 (#1900) | PR-7b | `verified-not-applicable`：新仓无 `selectedTableCells` 全局状态（grep 0 hit）；跨 cell 选区在 `editor/index.ts:93` 由 `isSelectionInSameBlock` 守卫早 return，不会进入 marktext 旧那条"删整 column 后引用悬空"的代码路径 |
 | 0a3fda63 + 2754e393 + 4b362e52 | architecture | post-refactor 修复合集（拆条） | 待拆 | `pending` |
 
 ## P1 — Parser / 渲染正确性
@@ -57,7 +57,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 5f191681 | parser | blockquote 内 list（exportMarkdown） | PR-2b | `test-only`（3 个 blockquote round-trip 测试） |
 | insertLineBreak 行尾空格 | serializer | 列表项内空行带尾随空格 | PR-2b | `fixed`（`insertLineBreak` 去掉尾随空格，保留 `>` 前缀；1 个回归测试） |
 | 70d49c30 | parser | `-foo` 误识 list item | PR-2a | `test-only`（marked v16 已要求 bullet 后接空格；2 个正负回归测试） |
-| 7b7a9424 | math | math block 嵌套 | PR-3 | `pending`（marktext fix 在 `paragraphCtrl.js` 编辑器层；PR-3 范围） |
+| 7b7a9424 | math | math block 嵌套 | PR-7b | `verified-not-applicable`：marktext `insertContainerBlock` 缺 anchor 校验导致 math 嵌套；新仓所有 container 创建路径（front menu / quick-insert / `$$` enter convert）都门控在 `paragraph.content`，`canTurnIntoMenu` 对 math/code/html/diagram/table 返回 `[]`。**新增 7 个回归测试**锁住 front-menu 门 |
 | d937fac0 | inline | inline 语法 (#1071 重复 `**\`x\`**` 只末尾加粗) | PR-2c | `test-only`（`lowerPriority` 的 `ignoreIndex` 已就位；2 个回归测试） |
 | 57af8304 | inline | link/image dest 含括号 (#1169) | PR-2c | `test-only`（`correctUrl` 用 `findClosingBracket` 已就位；3 个回归测试） |
 | 9c2f6cb3 | inline | inline math 样式 | — | `skipped`（CSS-only，新仓样式体系自有 inline math 样式） |
@@ -69,7 +69,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | c0853f64 | inline | auto link / extension | PR-2a | `test-only`（auto_link + auto_link_extension + 边界 guard 已就位；4 个回归测试） |
 | 1c42555a | block | 粘贴多行进 heading | PR-4a | `fixed`（提取 `mergePasteIntoHeading` 纯函数，6 个测试） |
 | dec7502e | block | setext heading | PR-2a | `test-only`（marked v16 lheading + walkTokens `headingStyle` 已就位；3 个回归测试） |
-| f00da152 | block | 嵌套块插表 crash | PR-3 | `pending`（marktext fix 在 `tableBlockCtrl.js` 编辑器层；PR-3 范围） |
+| f00da152 | block | 嵌套块插表 crash | PR-7b | `verified-not-applicable`：marktext 老 `createFigure` 缺 anchor 校验导致 math/code/html/table 内插表崩；新仓 `canTurnIntoMenu` 同一道门把 table 也挡在外，`/table` quick-insert 只对 `paragraph.content` 触发。**新增 6 个回归测试**复用 `canTurnIntoMenu` 门同时锁住 table 不可嵌入 |
 | 9cb2cbe8 | toc | TOC 更新（如做 TOC 参考） | PR-5 | `pending` |
 
 ## P2 — 编辑 / 光标 / 选择 / IME

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -49,10 +49,10 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 57cd04c5 | parser | CommonMark example 475 + 353/387/520/521 等 | PR-2a | `fixed`（canOpenEmphasis 阻断 mid-run `_`；link/reference_link 加 lowerPriority；5 个 CM spec 用例） |
 | ad5ddbf9 | parser | GFM example 558（link/image title 支持） | PR-2a | `test-only`（`parseSrcAndTitle` 已就位；4 个回归测试锁定 link/image title） |
 | 372fe02f | parser | list 解析 #870（task + bullet 混排拆分） | PR-2a | `test-only`（`compatibleTaskList` 已就位；1 个回归测试） |
-| 8891287b | parser | paragraph → list 转换 | PR-3 | `pending`（marktext fix 在 `updateCtrl.js` 编辑器键盘逻辑层；PR-2 范围外） |
+| 8891287b | parser | paragraph → list 转换 | PR-7a | `verified-not-applicable`：marktext fix 是 `updateCtrl.updateParagraphToList` 的 line-splitting 旧逻辑（无 marker 时 listItemLines 为空 → text 丢失）。新仓 `replaceBlockByLabel({label:'bullet-list', text})` 直接 `state.children[0].children[0].text = text` 整段保留，无 LIST_ITEM_REG 分行。**新增 6 个回归测试**锁住 contract |
 | 270d33f6 | parser | list item lexer/parser（CM 264/265 不同 marker 拆表） | PR-2a | `test-only`（marked v16 + `compatibleTaskList` 已就位；2 个 CM spec 测试） |
-| 04834032 | parser | tab 缩进 list | PR-3 | `pending`（marktext fix 在 `tabCtrl.js` 编辑器 keydown 逻辑；PR-2 范围外） |
-| 240d64aa | parser | 合并不同类型 list #706 | PR-4 | `pending`（marktext fix 在 `pasteCtrl.js` 粘贴流程；PR-4 clipboard 系列处理） |
+| 04834032 | parser | tab 缩进 list | PR-7a | `verified-not-applicable`：commit title 误导，实际修的是 markup code-block 内 Tab → Emmet HTML 展开（`parseSelector(undefined)` 崩 + `lastWord` 未限定到光标前 + postText 丢失）。新仓 `codeBlockContent.tabHandler` 已含 `lastWordBeforeCursor` + `postText` + `parseSelector(str='')` 三重修复。**新增 5 个回归测试**（含 mid-text、empty、non-markup 分支） |
+| 240d64aa | parser | 合并不同类型 list #706 | PR-7a | `verified-not-applicable`：marktext bug 在 `pasteCtrl` 合并 list-items 进现存 list 时未对齐 looseness。新仓 `pasteHandler` (`clipboard/index.ts:631-635`) 走 `for (state of remaining) ScrollPage.loadBlock(state.name).create(...) + insertAfter`，**每个粘贴状态独立成块**，不会与既存 list 合并，结构上不存在 looseness 错配 |
 | 02841ffd | parser | list 后续段落归属（exportMarkdown 缩进配置） | PR-2b | `test-only`（stateToMarkdown 已实现 indent/listIndent 拆分；4 个 marktext 缩进 fixture + 4 个扩展 round-trip） |
 | 5f191681 | parser | blockquote 内 list（exportMarkdown） | PR-2b | `test-only`（3 个 blockquote round-trip 测试） |
 | insertLineBreak 行尾空格 | serializer | 列表项内空行带尾随空格 | PR-2b | `fixed`（`insertLineBreak` 去掉尾随空格，保留 `>` 前缀；1 个回归测试） |
@@ -87,7 +87,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 0dc4b415 | table | cell backspace | PR-3d | `test-only`（`<br/>X` 末尾 backspace 旧路径在 contentState 内被特化；新仓走 `Format.backspaceHandler` token-based + 浏览器原生删除；建议 examples/ 手测 `<br/>` 后字符删除） |
 | 5fb130d9 | table | shift+tab 表格导航 | PR-3d | `fixed`（`tableCell.tabHandler` 新增 `event.shiftKey` 分支 + `previousContentInContext()`；3 个回归测试） |
 | 9e32c4a0 | table | cursor → next cell index 0 | PR-3d | `verified-not-applicable`（`tableCell.tabHandler` 已 `setCursor(0, 0, true)`，不会选中整 cell 文本） |
-| 0028a4bc | table | cell copy 异常 | PR-4 | `pending`（涉及 clipboard / 表格 cell copy，归 PR-4） |
+| 0028a4bc | table | cell copy 异常 | PR-7a | `verified-not-applicable`：marktext fix 是 `paragraphCtrl.selectTableCells` 单 cell descriptor 缺 `text` 字段。新仓无 selected-cells descriptor —— `getClipboardData` 同块分支直读 `anchorBlock.text.substring(begin, end)`（`clipboard/index.ts:133`）。**新增 3 个回归测试**锁住 table.cell.content 单块 copy 路径 |
 | 3fa8a9ae | autopair | inline code 内禁用 | PR-3b | `verified-not-applicable`（`content.ts:autoPair` 已有 `isInInlineCode` 参数 + `format.ts` 调用前用 `_checkCursorInTokenType` 计算；defensive 测试 2 个） |
 | 4278362f | autopair | inline math 内禁用 | PR-3b | `verified-not-applicable`（同上，`isInInlineMath` 参数已就位；defensive 测试 1 个） |
 | bbea7eca | autopair | 优化自动补全 | PR-3b | `verified-not-applicable`（`!/[a-z0-9]/i.test(preInputChar)` 已在 markdown-syntax 分支；defensive 测试 3 个） |

--- a/packages/core/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
+++ b/packages/core/src/block/content/codeBlockContent/__tests__/tabHandler.spec.ts
@@ -1,0 +1,147 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import CodeBlockContent from '../index';
+
+// Regression for marktext 04834032 "fix list indent by tab (#908)".
+// Despite the misleading commit title, the fix is actually about the
+// Emmet-style HTML tag expansion that fires when Tab is pressed inside
+// a markup / html / xml / svg / mathml code block.
+//
+// The pre-fix logic:
+//   - used the trailing word of the entire line (`text.split(/\s+/).pop()`)
+//     instead of the word immediately preceding the cursor;
+//   - dropped everything after the cursor when emitting the new HTML;
+//   - called `parseSelector(undefined)` when the line was empty.
+//
+// Post-fix logic (current `codeBlockContent.tabHandler`):
+//   - reads `lastWordBeforeCursor = text.substring(0, start.offset).split(/\s+/).pop()`;
+//   - composes `preText + html + postText` so trailing content survives;
+//   - `parseSelector` defaults to `''` so it never blows up on undefined.
+//
+// We drive the prototype directly with a structurally typed `this` so we
+// don't need a real Muya bootstrap.
+
+interface FakeCell {
+    text: string;
+    lang: string;
+    cursor: { start: number; end: number };
+    getCursor: () => { start: { offset: number }; end: { offset: number } };
+    setCursor: (start: number, end: number, _selected?: boolean) => void;
+    insertTab: () => void;
+}
+
+function makeFakeCodeContent(initial: {
+    text: string;
+    lang: string;
+    cursorAt: number;
+}): FakeCell {
+    return {
+        text: initial.text,
+        lang: initial.lang,
+        cursor: { start: initial.cursorAt, end: initial.cursorAt },
+        getCursor() {
+            return {
+                start: { offset: this.cursor.start },
+                end: { offset: this.cursor.end },
+            };
+        },
+        setCursor(start: number, end: number) {
+            this.cursor = { start, end };
+        },
+        insertTab: vi.fn(),
+    };
+}
+
+function makeKeyEvent() {
+    return {
+        preventDefault: vi.fn(),
+    } as unknown as KeyboardEvent;
+}
+
+describe('codeBlockContent.tabHandler — 04834032 Emmet expansion preserves postText', () => {
+    it('expands selector and keeps the text after the cursor intact', () => {
+        // Cursor sits right after `div` but more text follows.
+        const cell = makeFakeCodeContent({
+            text: 'div post-text',
+            lang: 'html',
+            cursorAt: 3,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        // Pre-fix bug: line became `<div></div>` and ` post-text` was lost.
+        // Post-fix expectation: trailing content survives.
+        expect(cell.text).toBe('<div></div> post-text');
+        expect(cell.text.includes('post-text')).toBe(true);
+    });
+
+    it('expands `div#id.cls` mid-line without dropping the suffix', () => {
+        const cell = makeFakeCodeContent({
+            text: 'div#main.box trailing',
+            lang: 'html',
+            cursorAt: 'div#main.box'.length,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        // The id="main" / class="box" expansion must remain anchored;
+        // the trailing word must survive.
+        expect(cell.text).toMatch(/^<div id="main" class="box"><\/div>/);
+        expect(cell.text.endsWith(' trailing')).toBe(true);
+    });
+
+    it('does not throw when called on an empty line (parseSelector default arg)', () => {
+        const cell = makeFakeCodeContent({
+            text: '',
+            lang: 'html',
+            cursorAt: 0,
+        });
+
+        expect(() => {
+            CodeBlockContent.prototype.tabHandler.call(
+                cell as unknown as CodeBlockContent,
+                makeKeyEvent(),
+            );
+        }).not.toThrow();
+    });
+
+    it('falls back to insertTab when no valid selector precedes the cursor in markup', () => {
+        const cell = makeFakeCodeContent({
+            text: 'not-a-tag ',
+            lang: 'html',
+            cursorAt: 'not-a-tag '.length,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        // `lastWordBeforeCursor` is the empty string after the trailing space →
+        // parseSelector → no tag → insertTab.
+        expect(cell.insertTab).toHaveBeenCalledTimes(1);
+        expect(cell.text).toBe('not-a-tag ');
+    });
+
+    it('falls back to insertTab for non-markup languages', () => {
+        const cell = makeFakeCodeContent({
+            text: 'div',
+            lang: 'javascript',
+            cursorAt: 3,
+        });
+
+        CodeBlockContent.prototype.tabHandler.call(
+            cell as unknown as CodeBlockContent,
+            makeKeyEvent(),
+        );
+
+        expect(cell.insertTab).toHaveBeenCalledTimes(1);
+        expect(cell.text).toBe('div');
+    });
+});

--- a/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
+++ b/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
@@ -1,0 +1,231 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import Table from '../index';
+
+// Regression for marktext commit 6293d408 "fix: #572 — cursor placement
+// after row/column delete". In marktext's `tableBlockCtrl`, when the user
+// removed a cell that contained the caret, the code set
+// `cursorBlock = getNextSibling(block)`. If the deleted cell sat on the
+// edge of the table, getNextSibling returned a now-detached node and the
+// caret evaporated. marktext's fix routed through `findNextBlockInLocation`,
+// which walks up to the parent row and across to the next valid descendant.
+//
+// In new muya, `Table.removeRow` and `Table.removeColumn` previously did
+// nothing more than detach DOM — they returned `void` and the caller in
+// `TableRowColumMenu.selectItem` had nothing to setCursor on, so after a
+// row/column delete the caret was left in an detached cell. PR-7b adds a
+// cell-content return value so callers can place the caret on a surviving
+// neighbour, restoring the same "click somewhere reasonable after a
+// destructive table edit" contract marktext had.
+//
+// These tests drive `removeRow` / `removeColumn` off the prototype with a
+// structurally typed `this`, the same pattern as
+// `tableCell/__tests__/tabHandler.spec.ts`, so the suite stays unit-level.
+
+interface IFakeContent {
+    setCursor: (begin: number, end: number, selected?: boolean) => void;
+}
+
+interface IFakeCell {
+    firstChild: IFakeContent;
+    prev: Nullable<IFakeCell>;
+    next: Nullable<IFakeCell>;
+    remove: () => void;
+}
+
+interface IFakeRow {
+    cells: IFakeCell[];
+    firstChild: IFakeCell;
+    prev: Nullable<IFakeRow>;
+    next: Nullable<IFakeRow>;
+    find: (offset: number) => Nullable<IFakeCell>;
+    remove: () => void;
+}
+
+interface IFakeTableInner {
+    rows: IFakeRow[];
+    firstChild: IFakeRow;
+    find: (offset: number) => Nullable<IFakeRow>;
+    length: () => number;
+    forEach: (cb: (row: IFakeRow) => void) => void;
+}
+
+type Nullable<T> = T | null | undefined;
+
+function makeContent(): IFakeContent {
+    return { setCursor: vi.fn() };
+}
+
+function makeCell(): IFakeCell {
+    const cell: IFakeCell = {
+        firstChild: makeContent(),
+        prev: null,
+        next: null,
+        remove: vi.fn(() => {
+            (cell as IFakeCell & { removed: boolean }).removed = true;
+        }),
+    } as IFakeCell;
+    return cell;
+}
+
+function makeRow(cellCount: number): IFakeRow {
+    const cells = Array.from({ length: cellCount }, makeCell);
+    for (let i = 0; i < cells.length; i++) {
+        cells[i].prev = i > 0 ? cells[i - 1] : null;
+        cells[i].next = i < cells.length - 1 ? cells[i + 1] : null;
+    }
+    const row: IFakeRow = {
+        cells,
+        firstChild: cells[0],
+        prev: null,
+        next: null,
+        find: (offset: number) => cells[offset],
+        remove: vi.fn(() => {
+            (row as IFakeRow & { removed: boolean }).removed = true;
+        }),
+    };
+    return row;
+}
+
+function makeTableInner(rowCount: number, cellCount: number): IFakeTableInner {
+    const rows = Array.from({ length: rowCount }, () => makeRow(cellCount));
+    for (let i = 0; i < rows.length; i++) {
+        rows[i].prev = i > 0 ? rows[i - 1] : null;
+        rows[i].next = i < rows.length - 1 ? rows[i + 1] : null;
+    }
+    return {
+        rows,
+        firstChild: rows[0],
+        find: (offset: number) => rows[offset],
+        length: () => rows.length,
+        forEach: (cb: (row: IFakeRow) => void) => rows.forEach(cb),
+    };
+}
+
+function makeFakeTable(rowCount: number, cellCount: number) {
+    const inner = makeTableInner(rowCount, cellCount);
+    return {
+        firstChild: inner,
+        columnCount: cellCount,
+        remove: vi.fn(),
+        // Match the production read-only getter `rowCount`.
+        get rowCountFromGetter() {
+            return inner.length();
+        },
+        inner,
+    };
+}
+
+describe('table.removeRow — returns surviving cell content for cursor placement (marktext 6293d408)', () => {
+    it('removes the targeted row and returns the next row\'s first cell content', () => {
+        const fake = makeFakeTable(3, 2);
+
+        const result = Table.prototype.removeRow.call(
+            fake as unknown as Table,
+            1,
+        );
+
+        // Pre-fix: returned undefined, leaving caller with nothing to focus.
+        // Post-fix: returns the surviving row's first cell content so the
+        // caller can `setCursor(0, 0)` on it.
+        expect(result).toBeTruthy();
+        expect(result).toBe(fake.inner.rows[2].cells[0].firstChild);
+        expect((fake.inner.rows[1] as any).removed).toBe(true);
+    });
+
+    it('falls back to the previous row\'s first cell when the last row is removed', () => {
+        const fake = makeFakeTable(3, 2);
+
+        const result = Table.prototype.removeRow.call(
+            fake as unknown as Table,
+            2,
+        );
+
+        expect(result).toBe(fake.inner.rows[1].cells[0].firstChild);
+        expect((fake.inner.rows[2] as any).removed).toBe(true);
+    });
+
+    it('removes the whole table when the only row is removed', () => {
+        const fake = makeFakeTable(1, 3);
+
+        const result = Table.prototype.removeRow.call(
+            fake as unknown as Table,
+            0,
+        );
+
+        // No surviving rows → no cell content to focus → null.
+        expect(result).toBeNull();
+        expect(fake.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns undefined and does nothing when the offset is out of range', () => {
+        const fake = makeFakeTable(2, 2);
+
+        const result = Table.prototype.removeRow.call(
+            fake as unknown as Table,
+            99,
+        );
+
+        expect(result).toBeUndefined();
+        for (const row of fake.inner.rows)
+            expect((row as any).removed).not.toBe(true);
+    });
+});
+
+describe('table.removeColumn — returns surviving cell content for cursor placement (marktext 6293d408)', () => {
+    it('removes column at offset and returns the first row\'s neighbour cell content', () => {
+        const fake = makeFakeTable(2, 3);
+        // Capture the cells in column 1 (the column we're going to remove).
+        const removedCol1Row0 = fake.inner.rows[0].cells[1];
+        const removedCol1Row1 = fake.inner.rows[1].cells[1];
+        // The surviving "next" sibling of the targeted cell in row 0 is
+        // column 2 (cells[2]) — that's what the fix returns so the caller
+        // can place the caret on a cell that is still attached.
+        const expectedSurvivor = fake.inner.rows[0].cells[2].firstChild;
+
+        const result = Table.prototype.removeColumn.call(
+            fake as unknown as Table,
+            1,
+        );
+
+        expect(result).toBe(expectedSurvivor);
+        expect((removedCol1Row0 as any).removed).toBe(true);
+        expect((removedCol1Row1 as any).removed).toBe(true);
+    });
+
+    it('falls back to the previous-cell content when the last column is removed', () => {
+        const fake = makeFakeTable(2, 3);
+        const expectedSurvivor = fake.inner.rows[0].cells[1].firstChild;
+
+        const result = Table.prototype.removeColumn.call(
+            fake as unknown as Table,
+            2,
+        );
+
+        expect(result).toBe(expectedSurvivor);
+    });
+
+    it('removes the whole table when the only column is removed', () => {
+        const fake = makeFakeTable(2, 1);
+
+        Table.prototype.removeColumn.call(fake as unknown as Table, 0);
+
+        expect(fake.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing and returns undefined when the offset is out of range', () => {
+        const fake = makeFakeTable(2, 2);
+
+        const result = Table.prototype.removeColumn.call(
+            fake as unknown as Table,
+            5,
+        );
+
+        expect(result).toBeUndefined();
+        // No cells removed.
+        for (const row of fake.inner.rows) {
+            for (const cell of row.cells)
+                expect((cell as any).removed).not.toBe(true);
+        }
+    });
+});

--- a/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
+++ b/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
@@ -108,10 +108,13 @@ function makeFakeTable(rowCount: number, cellCount: number) {
         firstChild: inner,
         columnCount: cellCount,
         remove: vi.fn(),
-        // Match the production read-only getter `rowCount`.
-        get rowCountFromGetter() {
-            return inner.length();
-        },
+        // The whole-table-removed branch (marktext 6293d408 cover-the-edge
+        // case) calls `nextContentInContext()` / `previousContentInContext()`
+        // on `this` before `this.remove()`. Stub both to return null in the
+        // base fixture; specific tests override to assert the outside-
+        // content fallback.
+        nextContentInContext: vi.fn(() => null),
+        previousContentInContext: vi.fn(() => null),
         inner,
     };
 }
@@ -145,7 +148,7 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
         expect((fake.inner.rows[2] as any).removed).toBe(true);
     });
 
-    it('removes the whole table when the only row is removed', () => {
+    it('removes the whole table when the only row is removed, and returns null without an outside fallback', () => {
         const fake = makeFakeTable(1, 3);
 
         const result = Table.prototype.removeRow.call(
@@ -153,9 +156,37 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
             0,
         );
 
-        // No surviving rows → no cell content to focus → null.
+        // No surviving rows AND no outside-of-table content → null.
         expect(result).toBeNull();
         expect(fake.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns the next outside-of-table content when the only row is removed (Copilot PR-7b review follow-up)', () => {
+        const fake = makeFakeTable(1, 3);
+        const outsideContent = { setCursor: vi.fn() };
+        fake.nextContentInContext = vi.fn(() => outsideContent as any);
+
+        const result = Table.prototype.removeRow.call(
+            fake as unknown as Table,
+            0,
+        );
+
+        expect(result).toBe(outsideContent);
+        expect(fake.remove).toHaveBeenCalledTimes(1);
+        expect(fake.nextContentInContext).toHaveBeenCalled();
+    });
+
+    it('falls back to previousContentInContext when there is no next content outside the table', () => {
+        const fake = makeFakeTable(1, 3);
+        const prevOutside = { setCursor: vi.fn() };
+        fake.previousContentInContext = vi.fn(() => prevOutside as any);
+
+        const result = Table.prototype.removeRow.call(
+            fake as unknown as Table,
+            0,
+        );
+
+        expect(result).toBe(prevOutside);
     });
 
     it('returns undefined and does nothing when the offset is out of range', () => {
@@ -208,8 +239,27 @@ describe('table.removeColumn — returns surviving cell content for cursor place
     it('removes the whole table when the only column is removed', () => {
         const fake = makeFakeTable(2, 1);
 
-        Table.prototype.removeColumn.call(fake as unknown as Table, 0);
+        const result = Table.prototype.removeColumn.call(
+            fake as unknown as Table,
+            0,
+        );
 
+        expect(fake.remove).toHaveBeenCalledTimes(1);
+        // No outside content stubbed → null.
+        expect(result).toBeNull();
+    });
+
+    it('returns the next outside-of-table content when the only column is removed (Copilot PR-7b review follow-up)', () => {
+        const fake = makeFakeTable(2, 1);
+        const outsideContent = { setCursor: vi.fn() };
+        fake.nextContentInContext = vi.fn(() => outsideContent as any);
+
+        const result = Table.prototype.removeColumn.call(
+            fake as unknown as Table,
+            0,
+        );
+
+        expect(result).toBe(outsideContent);
         expect(fake.remove).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/core/src/block/gfm/table/index.ts
+++ b/packages/core/src/block/gfm/table/index.ts
@@ -179,15 +179,30 @@ class Table extends Parent {
         return firstCellInNewColumn!.firstChild as TableCellContent;
     }
 
-    removeRow(offset: number) {
-        const row = (this.firstChild as TableInner).find(offset);
+    removeRow(offset: number): Nullable<TableCellContent> {
+        const inner = this.firstChild as TableInner;
+        const row = inner.find(offset);
         if (row == null)
             return;
 
+        // Marktext 6293d408 (#572) backport: capture a surviving neighbour
+        // BEFORE the detach so the caller can place the caret on a cell that
+        // is still attached to the DOM. Prefer the next row, fall back to the
+        // previous, and signal "no surviving rows" with null so the caller
+        // can short-circuit setCursor.
+        const survivor = (row.next as TableRow | null) ?? (row.prev as TableRow | null);
+
         row.remove();
+
+        if (survivor == null) {
+            this.remove();
+            return null;
+        }
+
+        return (survivor.firstChild as TableBodyCell).firstChild as TableCellContent;
     }
 
-    removeColumn(offset: number) {
+    removeColumn(offset: number): Nullable<TableCellContent> {
         const { columnCount } = this;
         if (offset < 0 || offset >= columnCount) {
             debug.warn(`column at ${offset} is not existed.`);
@@ -195,14 +210,28 @@ class Table extends Parent {
         }
 
         const table = this.firstChild as TableInner;
-        if (this.columnCount === 1)
-            return this.remove();
+        if (this.columnCount === 1) {
+            this.remove();
+            return null;
+        }
+
+        // Capture the first row's surviving neighbour cell before mutation so
+        // the caller can setCursor on a still-attached cell after the column
+        // detach. Same intent as marktext 6293d408 — but applied per column
+        // since the new architecture removes one cell per row in a loop.
+        const firstRow = table.firstChild as TableRow;
+        const targetCellInFirstRow = firstRow.find(offset) as TableBodyCell | null;
+        const neighbourCell
+            = (targetCellInFirstRow?.next as TableBodyCell | null)
+                ?? (targetCellInFirstRow?.prev as TableBodyCell | null);
 
         table.forEach((row) => {
             const cell = (row as TableRow).find(offset);
             if (cell)
                 cell.remove();
         });
+
+        return (neighbourCell?.firstChild as TableCellContent | undefined) ?? null;
     }
 
     alignColumn(offset: number, value: string) {

--- a/packages/core/src/block/gfm/table/index.ts
+++ b/packages/core/src/block/gfm/table/index.ts
@@ -1,6 +1,7 @@
 import type { Muya } from '../../../muya';
 import type { ITableState } from '../../../state/types';
 import type { Nullable } from '../../../types';
+import type Content from '../../base/content';
 import type TableCellContent from '../../content/tableCell';
 import type { TBlockPath } from '../../types';
 import type TableBodyCell from './cell';
@@ -179,7 +180,7 @@ class Table extends Parent {
         return firstCellInNewColumn!.firstChild as TableCellContent;
     }
 
-    removeRow(offset: number): Nullable<TableCellContent> {
+    removeRow(offset: number): Nullable<Content> {
         const inner = this.firstChild as TableInner;
         const row = inner.find(offset);
         if (row == null)
@@ -188,21 +189,27 @@ class Table extends Parent {
         // Marktext 6293d408 (#572) backport: capture a surviving neighbour
         // BEFORE the detach so the caller can place the caret on a cell that
         // is still attached to the DOM. Prefer the next row, fall back to the
-        // previous, and signal "no surviving rows" with null so the caller
-        // can short-circuit setCursor.
+        // previous; if no rows remain after this delete, capture a content
+        // block OUTSIDE the table so the caret never lands inside the
+        // about-to-be-detached table itself.
         const survivor = (row.next as TableRow | null) ?? (row.prev as TableRow | null);
+        // Always grab the outside-of-table fallback as well, in case the
+        // whole table is going away. `nextContentInContext` / `prev` walk
+        // out of the table by design.
+        const outsideContent
+            = this.nextContentInContext() ?? this.previousContentInContext();
 
         row.remove();
 
         if (survivor == null) {
             this.remove();
-            return null;
+            return outsideContent ?? null;
         }
 
         return (survivor.firstChild as TableBodyCell).firstChild as TableCellContent;
     }
 
-    removeColumn(offset: number): Nullable<TableCellContent> {
+    removeColumn(offset: number): Nullable<Content> {
         const { columnCount } = this;
         if (offset < 0 || offset >= columnCount) {
             debug.warn(`column at ${offset} is not existed.`);
@@ -211,8 +218,13 @@ class Table extends Parent {
 
         const table = this.firstChild as TableInner;
         if (this.columnCount === 1) {
+            // Same outside-of-table fallback as removeRow when the whole
+            // table is removed — never leave the caret inside a detached
+            // subtree.
+            const outsideContent
+                = this.nextContentInContext() ?? this.previousContentInContext();
             this.remove();
-            return null;
+            return outsideContent ?? null;
         }
 
         // Capture the first row's surviving neighbour cell before mutation so

--- a/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -61,3 +61,48 @@ describe('clipboard.getClipboardData — single-block selection is not HTML-esca
         expect(text).toBe('');
     });
 });
+
+// Regression for marktext commit 0028a4bc (#2375 — "Fix issue with not being
+// able to copy table cell"). marktext's old `paragraphCtrl.selectTableCells`
+// built a virtual {key, top, right, bottom, left, ...} cell descriptor for
+// single-cell copy, but forgot the `text` field; the descriptor went to the
+// clipboard with an empty body, so copying a cell produced "".
+//
+// New muya's `getClipboardData` doesn't have a separate "selected table
+// cell" data structure: when the user copies inside a single
+// `table.cell.content` block, the `isSelectionInSameBlock` branch simply
+// reads `anchorBlock.text.substring(begin, end)`. So the text always survives
+// — provided the call site still feeds the cell's text into that substring.
+// This defensive test pins that contract.
+describe('clipboard.getClipboardData — single table-cell copy keeps the cell text (marktext 0028a4bc)', () => {
+    it('copies the full cell text when the user selects everything in the cell', () => {
+        const cellText = 'cell <body> & "value"';
+        const clipboard = makeClipboard(cellText, 0, cellText.length);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe(cellText);
+        expect(text).not.toBe('');
+    });
+
+    it('copies a partial selection inside the cell verbatim', () => {
+        // Selecting `<body>` out of the middle of a cell — the substring
+        // must not be HTML-escaped or stripped.
+        const cellText = 'pre <body> post';
+        const clipboard = makeClipboard(cellText, 4, 10);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe('<body>');
+    });
+
+    it('returns the cell text even when it is the only content', () => {
+        // The original marktext bug: descriptor had no `text` → output "".
+        // Here we assert the path that fills it.
+        const clipboard = makeClipboard('only-cell', 0, 9);
+
+        const { text } = clipboard.getClipboardData();
+
+        expect(text).toBe('only-cell');
+    });
+});

--- a/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -25,20 +25,32 @@ function fakeMuya() {
     } as unknown as Muya;
 }
 
-function selectionOver(text: string, begin: number, end: number) {
+function selectionOver(
+    text: string,
+    begin: number,
+    end: number,
+    blockName: string = 'paragraph.content',
+) {
     return {
         isSelectionInSameBlock: true,
         anchor: { offset: begin },
         focus: { offset: end },
-        anchorBlock: { text } as any,
-        focusBlock: { text } as any,
+        anchorBlock: { text, blockName } as any,
+        focusBlock: { text, blockName } as any,
     };
 }
 
-function makeClipboard(text: string, begin: number, end: number) {
+function makeClipboard(
+    text: string,
+    begin: number,
+    end: number,
+    blockName?: string,
+) {
     const clipboard = new Clipboard(fakeMuya());
     Object.defineProperty(clipboard, 'selection', {
-        get: () => ({ getSelection: () => selectionOver(text, begin, end) }),
+        get: () => ({
+            getSelection: () => selectionOver(text, begin, end, blockName),
+        }),
     });
     Object.defineProperty(clipboard, 'scrollPage', { get: () => null });
     return clipboard;
@@ -77,7 +89,12 @@ describe('clipboard.getClipboardData — single-block selection is not HTML-esca
 describe('clipboard.getClipboardData — single table-cell copy keeps the cell text (marktext 0028a4bc)', () => {
     it('copies the full cell text when the user selects everything in the cell', () => {
         const cellText = 'cell <body> & "value"';
-        const clipboard = makeClipboard(cellText, 0, cellText.length);
+        const clipboard = makeClipboard(
+            cellText,
+            0,
+            cellText.length,
+            'table.cell.content',
+        );
 
         const { text } = clipboard.getClipboardData();
 
@@ -89,7 +106,7 @@ describe('clipboard.getClipboardData — single table-cell copy keeps the cell t
         // Selecting `<body>` out of the middle of a cell — the substring
         // must not be HTML-escaped or stripped.
         const cellText = 'pre <body> post';
-        const clipboard = makeClipboard(cellText, 4, 10);
+        const clipboard = makeClipboard(cellText, 4, 10, 'table.cell.content');
 
         const { text } = clipboard.getClipboardData();
 
@@ -99,7 +116,7 @@ describe('clipboard.getClipboardData — single table-cell copy keeps the cell t
     it('returns the cell text even when it is the only content', () => {
         // The original marktext bug: descriptor had no `text` → output "".
         // Here we assert the path that fills it.
-        const clipboard = makeClipboard('only-cell', 0, 9);
+        const clipboard = makeClipboard('only-cell', 0, 9, 'table.cell.content');
 
         const { text } = clipboard.getClipboardData();
 

--- a/packages/core/src/ui/paragraphFrontMenu/__tests__/canTurnIntoMenu.spec.ts
+++ b/packages/core/src/ui/paragraphFrontMenu/__tests__/canTurnIntoMenu.spec.ts
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { canTurnIntoMenu } from '../config';
+
+// Regression for marktext commit 7b7a9424 "should not nest math block into
+// other math block (#1153)".
+//
+// In marktext, `insertContainerBlock(functionType, block)` walked from the
+// caret block up to the paragraph and replaced it with a new container
+// (math/html/code/diagram). When the caret was already inside another
+// container (e.g. inside a math-block's code line), the old code happily
+// constructed a NEW container at the wrong level — yielding a math-block
+// nested inside a math-block. The marktext fix added `getAnchor(block)` +
+// "if no anchor, abort" + "don't remove the block when not a paragraph".
+//
+// New muya has no `insertContainerBlock`. All math-block / html-block /
+// code-block / diagram creation flows are gated to paragraph blocks:
+//   • `ParagraphFrontMenu.canTurnIntoMenu(block)` returns `[]` for any
+//     non-paragraph container, so the user can't open the "turn into"
+//     submenu from inside a math/code/html/diagram block at all.
+//   • `ParagraphQuickInsertMenu` only fires on `paragraph.content`
+//     (`block.blockName !== 'paragraph.content' return;`) and only when the
+//     anchorBlock is `instanceof ParagraphContent`. Inside a math-block
+//     you're in a `codeblock.content`, not `paragraph.content`, so the menu
+//     never opens — `/math` can't reach `replaceBlockByLabel`.
+//   • `ParagraphContent._enterConvert` is the auto-convert for `$$` and is
+//     only reachable from paragraph enterHandler.
+//
+// These tests pin the front-menu gate. The quick-insert + enter-convert
+// gates are at the listen() level and out of unit-test reach without a
+// full Muya bootstrap, but the front-menu gate is enough to demonstrate
+// that the user has no UI path to nest a math-block inside a math-block.
+
+function fakeBlock(blockName: string, paragraphText: string = ''): any {
+    return {
+        blockName,
+        firstContentInDescendant() {
+            return { text: paragraphText };
+        },
+    };
+}
+
+describe('canTurnIntoMenu — no nesting math/code/html/diagram inside themselves (marktext 7b7a9424)', () => {
+    it('returns [] for a math-block (front menu shows no turn-into list)', () => {
+        expect(canTurnIntoMenu(fakeBlock('math-block'))).toEqual([]);
+    });
+
+    it('returns [] for an html-block', () => {
+        expect(canTurnIntoMenu(fakeBlock('html-block'))).toEqual([]);
+    });
+
+    it('returns [] for a code-block', () => {
+        expect(canTurnIntoMenu(fakeBlock('code-block'))).toEqual([]);
+    });
+
+    it('returns [] for a diagram block', () => {
+        expect(canTurnIntoMenu(fakeBlock('diagram'))).toEqual([]);
+    });
+
+    it('returns [] for a table block (turning a table into math would also crash)', () => {
+        expect(canTurnIntoMenu(fakeBlock('table'))).toEqual([]);
+    });
+
+    it('still offers conversion for a paragraph (sanity — gate is selective)', () => {
+        const items = canTurnIntoMenu(fakeBlock('paragraph', ''));
+        // Empty paragraph: all menu items except frontmatter; non-empty
+        // paragraph: only paragraph/heading/quote/list. Both must be > 0.
+        expect(items.length).toBeGreaterThan(0);
+        // Both an empty paragraph and a typed paragraph must keep
+        // math-block reachable via SOME paragraph path (the
+        // `paragraphIsEmpty` branch returns ALL except frontmatter,
+        // including math-block).
+        const emptyItems = canTurnIntoMenu(fakeBlock('paragraph', ''));
+        expect(emptyItems.some((i: { label: string }) => i.label === 'math-block')).toBe(true);
+    });
+
+    it('non-empty paragraph offers no math-block turn-into (only inline/list types)', () => {
+        // The non-empty branch filters down to paragraph/atx-heading/
+        // block-quote/list — math-block is intentionally excluded so a
+        // half-typed paragraph can't auto-jump into a math container.
+        const items = canTurnIntoMenu(fakeBlock('paragraph', 'hello world'));
+        expect(items.some((i: { label: string }) => i.label === 'math-block')).toBe(false);
+    });
+});
+
+// Regression for marktext commit f00da152 (#812 — "insert table into `table`,
+// `html`, `code`, `math` block will cause wrong markdown syntax"). The bug:
+// `createFigure` was reachable from inside non-paragraph blocks; the new
+// `<figure><table/></figure>` ended up nested inside another table cell or
+// code-block content, producing garbage markdown that subsequently
+// crashed on re-parse. marktext's fix added `getAnchor(block)` + "abort if
+// no anchor" gating.
+//
+// New muya gates the same way at the UI layer: `canTurnIntoMenu` returns
+// `[]` for table/html-block/code-block/math-block/diagram, so the front
+// menu never offers "turn into table" from those contexts. The quick-insert
+// `/table` shortcut likewise only fires on `paragraph.content`. The cases
+// already locked above (math-block, html-block, code-block, diagram, table)
+// also cover this commit — a single gate keeps both 7b7a9424 and f00da152
+// off the UI.
+
+describe('canTurnIntoMenu — no inserting tables inside non-paragraph containers (marktext f00da152)', () => {
+    it('returns [] for math-block (cannot offer turn-into-table)', () => {
+        const items = canTurnIntoMenu(fakeBlock('math-block'));
+        expect(items.some((i: { label: string }) => i.label === 'table')).toBe(false);
+    });
+
+    it('returns [] for html-block (cannot offer turn-into-table)', () => {
+        const items = canTurnIntoMenu(fakeBlock('html-block'));
+        expect(items.some((i: { label: string }) => i.label === 'table')).toBe(false);
+    });
+
+    it('returns [] for code-block (cannot offer turn-into-table)', () => {
+        const items = canTurnIntoMenu(fakeBlock('code-block'));
+        expect(items.some((i: { label: string }) => i.label === 'table')).toBe(false);
+    });
+
+    it('returns [] for table (cannot offer turn-into-table on a table)', () => {
+        const items = canTurnIntoMenu(fakeBlock('table'));
+        expect(items.some((i: { label: string }) => i.label === 'table')).toBe(false);
+    });
+
+    it('empty paragraph DOES include table — sanity that the gate is positive elsewhere', () => {
+        const items = canTurnIntoMenu(fakeBlock('paragraph', ''));
+        expect(items.some((i: { label: string }) => i.label === 'table')).toBe(true);
+    });
+
+    it('non-empty paragraph excludes table from the turn-into list', () => {
+        const items = canTurnIntoMenu(fakeBlock('paragraph', 'typed text'));
+        expect(items.some((i: { label: string }) => i.label === 'table')).toBe(false);
+    });
+});

--- a/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
+++ b/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
@@ -1,0 +1,216 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { ScrollPage } from '../../../block/scrollPage';
+import { replaceBlockByLabel } from '../config';
+
+// Regression for marktext 8891287b "fix paragraph turn into list bug (#1025)".
+//
+// In marktext, the old `updateCtrl.updateParagraphToList` ran a loop on
+// `text.split('\n')` looking for `LIST_ITEM_REG.test(l)` matches and dropped
+// every line that didn't match into `preParagraphLines`. When the conversion
+// was triggered from the front menu (no `marker` argument), no line ever
+// matched the bullet/order regex, so the entire paragraph contents were
+// silently lost.
+//
+// The marktext fix branched: `if (marker) { …split-and-strip… } else
+// { listItemLines = lines /* take the whole input verbatim */ }`.
+//
+// The new architecture has no `updateParagraphToList` at all — front-menu
+// conversion is `replaceBlockByLabel({label: 'bullet-list', text})`, which
+// builds the new list from `deepClone(emptyStates['bullet-list'])` and assigns
+// the whole `text` to `state.children[0].children[0].text` (a single
+// list-item's paragraph). No line splitting, no marker regex.
+//
+// We unit-test `replaceBlockByLabel` by stubbing `ScrollPage.loadBlock(...).create`
+// so we can capture the state object it builds, then assert that the text
+// the user typed survives verbatim.
+
+interface ICapturedCreate {
+    label: string;
+    state: any;
+}
+
+function setupCreateSpy(): {
+    captured: ICapturedCreate[];
+    restore: () => void;
+} {
+    const captured: ICapturedCreate[] = [];
+    const realLoadBlock = ScrollPage.loadBlock.bind(ScrollPage);
+    const spy = vi.spyOn(ScrollPage, 'loadBlock').mockImplementation((label: string) => {
+        return {
+            create: (_muya: any, state: any) => {
+                captured.push({ label, state });
+                // Return a fake block with the surface `replaceBlockByLabel`
+                // touches afterwards (`replaceWith` / `firstContentInDescendant`).
+                return makeFakeBlock(state);
+            },
+        } as any;
+    });
+
+    return {
+        captured,
+        restore: () => {
+            spy.mockRestore();
+            // The mock above does not call the real `loadBlock`, but reset for safety.
+            void realLoadBlock;
+        },
+    };
+}
+
+function makeFakeBlock(state: any): any {
+    const fake: any = {
+        state,
+        parent: { insertAfter: vi.fn() },
+        replaceWith: vi.fn(),
+        firstContentInDescendant: () => ({
+            text: '',
+            setCursor: vi.fn(),
+        }),
+    };
+    return fake;
+}
+
+function makeFakeOriginBlock(): any {
+    return {
+        replaceWith: vi.fn(),
+    };
+}
+
+function makeFakeMuya(): any {
+    return {
+        options: {
+            preferLooseListItem: false,
+            bulletListMarker: '-',
+            orderListDelimiter: '.',
+            frontmatterType: '---',
+        },
+    };
+}
+
+describe('replaceBlockByLabel — paragraph→list keeps text verbatim (marktext 8891287b)', () => {
+    it('bullet-list: puts plain paragraph text into the first list-item paragraph', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'bullet-list',
+                text: 'plain text',
+            });
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list).toBeTruthy();
+            expect(list.state.name).toBe('bullet-list');
+            expect(list.state.children).toHaveLength(1);
+            expect(list.state.children[0].name).toBe('list-item');
+            expect(list.state.children[0].children[0].name).toBe('paragraph');
+            expect(list.state.children[0].children[0].text).toBe('plain text');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('does not strip a leading `- ` from the bullet-list text (no marker regex)', () => {
+        // Pre-fix marktext (front-menu trigger, no marker) dropped this entire
+        // text since no line matched the bullet regex while `isPushedListItemLine`
+        // stayed false. New muya must keep it verbatim.
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'bullet-list',
+                text: '- foo',
+            });
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list.state.children[0].children[0].text).toBe('- foo');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('order-list: does not strip a leading `1. ` from the text', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'order-list',
+                text: '1. foo',
+            });
+
+            const list = captured.find(c => c.label === 'order-list')!;
+            expect(list.state.children[0].children[0].text).toBe('1. foo');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('keeps multi-line text in a single list-item paragraph (no split)', () => {
+        // Pre-fix marktext walked `text.split("\n")` and partitioned lines
+        // into preParagraphLines vs listItemLines. New muya never splits —
+        // the whole string goes into one paragraph.
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'bullet-list',
+                text: 'first line\nsecond line\nthird',
+            });
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list.state.children).toHaveLength(1);
+            expect(list.state.children[0].children[0].text).toBe(
+                'first line\nsecond line\nthird',
+            );
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('task-list: first item has the checkbox meta and the input text', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            replaceBlockByLabel({
+                block: makeFakeOriginBlock(),
+                muya: makeFakeMuya(),
+                label: 'task-list',
+                text: 'todo item',
+            });
+
+            const list = captured.find(c => c.label === 'task-list')!;
+            expect(list.state.children[0].name).toBe('task-list-item');
+            expect(list.state.children[0].meta).toEqual({ checked: false });
+            expect(list.state.children[0].children[0].text).toBe('todo item');
+        }
+        finally {
+            restore();
+        }
+    });
+
+    it('empty text is acceptable (no exception, default empty paragraph)', () => {
+        const { captured, restore } = setupCreateSpy();
+        try {
+            expect(() => {
+                replaceBlockByLabel({
+                    block: makeFakeOriginBlock(),
+                    muya: makeFakeMuya(),
+                    label: 'bullet-list',
+                    text: '',
+                });
+            }).not.toThrow();
+
+            const list = captured.find(c => c.label === 'bullet-list')!;
+            expect(list.state.children[0].children[0].text).toBe('');
+        }
+        finally {
+            restore();
+        }
+    });
+});

--- a/packages/core/src/ui/tableColumnToolbar/index.ts
+++ b/packages/core/src/ui/tableColumnToolbar/index.ts
@@ -152,7 +152,14 @@ export class TableColumnToolbar extends BaseFloat {
 
         switch (item.type) {
             case 'remove': {
-                block.table.removeColumn(offset);
+                // Marktext 6293d408 (#572) backport: removeColumn now returns
+                // a content block to re-anchor the caret on (inside the table
+                // if columns remain, outside the table if the whole table was
+                // removed). Without this setCursor the caret stays in the
+                // detached cell.
+                const cursorBlock = block.table.removeColumn(offset);
+                if (cursorBlock)
+                    cursorBlock.setCursor(0, 0);
 
                 return this.hide();
             }

--- a/packages/core/src/ui/tableRowColumMenu/index.ts
+++ b/packages/core/src/ui/tableRowColumMenu/index.ts
@@ -119,10 +119,16 @@ export class TableRowColumMenu extends BaseFloat {
                 cursorBlock.setCursor(0, 0);
         }
         else {
-            if (target === 'row')
-                table.removeRow(rowCount);
-            else
-                table.removeColumn(columnCount);
+            // Marktext 6293d408 (#572) backport: after a row/column delete,
+            // the caret used to live inside a now-detached cell. The table
+            // mutators now return a surviving neighbour cell's content so we
+            // can re-anchor the caret on a still-attached cell.
+            const cursorBlock = target === 'row'
+                ? table.removeRow(rowCount)
+                : table.removeColumn(columnCount);
+
+            if (cursorBlock)
+                cursorBlock.setCursor(0, 0);
         }
 
         this.hide();


### PR DESCRIPTION
## Summary

PR-7 series cleanup, batch B (4 marktext commits). Three structurally non-applicable, one real cursor regression fixed.

Stacked on top of #215 (PR-7a). Review the 3 commits unique to this PR.

| Marktext commit | Title | Status | Tests added |
|---|---|---|---|
| [7b7a9424](https://github.com/marktext/marktext/commit/7b7a9424) | no nested math block (#1153) | verified-not-applicable | 7 |
| [f00da152](https://github.com/marktext/marktext/commit/f00da152) | no insert table into table/html/code/math (#812) | verified-not-applicable | 6 |
| [6293d408](https://github.com/marktext/marktext/commit/6293d408) | tableBlockCtrl cursor after row/col delete (#572) | **fixed** | 8 |
| [f99addd2](https://github.com/marktext/marktext/commit/f99addd2) | selectedTableCells cleanup (#1900) | verified-not-applicable | 0 (no state to test) |

### Root-cause summary per commit

- **7b7a9424 / f00da152** — Both collapse to the same front-menu gate: `canTurnIntoMenu(block)` returns `[]` for `math-block`/`html-block`/`code-block`/`diagram`/`table` (`paragraphFrontMenu/config.ts:43-79`). Quick-insert (`/math`, `/table`) only fires on `paragraph.content`. 13 tests pin both directions of that gate, plus `paragraph` (positive) controls. red→green verified by injecting "allow math-block turn-into for default branch" — 5 of 13 tests caught it.
- **6293d408** — *Real regression*. New muya's `Table.removeRow`/`Table.removeColumn` did nothing but detach DOM — the caller in `TableRowColumMenu.selectItem` had no cell to setCursor on, so after deleting a row/column the caret floated on a detached node. Fixed both methods to capture a surviving neighbour (next row / prev row / next cell / prev cell) BEFORE the detach and return its content; caller does `setCursor(0, 0)` on the return. red→green: initial run of 8 prototype-level tests fails 4 with the prior void-return signature; all 8 green after.
- **f99addd2** — New repo has no `selectedTableCells` global state at all (grep returns 0). Cross-cell selections early-return at `editor/index.ts:93` via `isSelectionInSameBlock` guard, so the dangling-reference path that crashed marktext (`Cannot destructure property row of i as it is null`) is unreachable.

## Test plan
- [x] `pnpm --filter @muyajs/core test` (200 total passed)
- [x] `pnpm --filter @muyajs/core lint:types` clean
- [x] `pnpm check-circular` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)