### PR TITLE
test: backport marktext muya parser test suites (PR-6b)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -172,7 +172,17 @@ Spec runner 用 `renderToStaticHTML(..., { sanitize: false })` 跑——衡量�
 
 `normalizeHtml` 规范化：兼属性名排序、self-closing void 标签统一、相邻 tag 间空白折叠（`>(WS)<` → `><`）、void 标签后空白剥离。`<pre>`/`<code>` 内容（如行末 `\n`）保留——因为 collapse 只匹配纯空白 token 间隔，content 字符不动。
 
-### PR-6b 待办（独立 PR，PR-6a 合并后做）
+### PR-6b 交付（2026-05-20）
+
+完成 marktext 测试补齐三件套：
+
+- **footnote 510 行补齐**：`utils/marked/extensions/__tests__/footnote.spec.ts` 从 13 → 21 个测试，新增 8 个 multi-line body 场景（next-line / next-paragraph / 多段落 body / 嵌套 list / 嵌套 code block / 终止于非缩进段落 / 终止于不足 4-space 缩进）。顺手修了 `footnote.ts` cleanup 路径的小 bug：第一行 4-space 缩进未剥离导致 multi-line body 被误识别成 indented code block（解决方案：cleanup 加一道 `^ {4}` strip）。
+- **markdown-basic round-trip**：新增 `test/spec/roundTrip.spec.ts` + 11 个 marktext fixture（`test/spec/fixtures/marktext-round-trip/{common,gfm}/`）。15 个测试（11 stability + 4 strict identity round-trip）。
+- **list-indentation 5 个策略**：`state/__tests__/listSerialization.spec.ts` 原 11 个 + 新增 `dfm` (Daring Fireball) 策略 → 12 个。
+
+合计 PR-6b 新增 24 个测试，1 个 footnote parser bug fix。
+
+### PR-6b 待办（旧；保留为后续追踪参考）
 
 目标：补足"非 bug regression"的测试覆盖。PR-2~5 的每条 fix 都自带回归测试，但 happy-path、合规性、广覆盖的测试目前稀疏。
 
@@ -218,6 +228,6 @@ Spec runner 用 `renderToStaticHTML(..., { sanitize: false })` 跑——衡量�
 | PR-4c (P3 抓标题) | 1 | 1 | 100%（fixed，5 个测试） |
 | PR-5 | 18+ | 0 | 0% |
 | PR-6a | — | done | spec 合规基础设施落地（CM 572/652 = 87.7%, GFM 580/672 = 86.3%，1324 spec 测试 + 8 normalizer 单测 + 18 个 renderToStaticHTML 单测） |
-| PR-6b | — | 0 | 0%（PR-6a 合并后启动；footnote 510 行 + markdown-basic round-trip + list-indentation 补齐） |
+| PR-6b | — | done | marktext 测试补齐落地（footnote 8 个新测试 + 1 个 parser fix；round-trip 15 个测试 + 11 fixture；list-indent +1 dfm 策略） |
 
 最后更新：2026-05-20

--- a/packages/core/src/state/__tests__/listSerialization.spec.ts
+++ b/packages/core/src/state/__tests__/listSerialization.spec.ts
@@ -234,4 +234,36 @@ sep
 `;
         expect(roundTrip(md, 4)).toBe(md);
     });
+
+    // Daring Fireball Markdown Spec: nested list items indent by a hard
+    // 4 spaces regardless of marker width. Backported from marktext
+    // `markdown-list-indentation.spec.js`, last case in the suite.
+    it('indent using Daring Fireball Markdown Spec (dfm) — round-trips marktext fixture', () => {
+        const md = `start
+
+- foo
+- foo
+    - foo
+    - foo
+        - foo
+        - foo
+            - foo
+    - foo
+- foo
+
+sep
+
+1. foo
+2. foo
+    1. foo
+    2. foo
+        1. foo
+    3. foo
+3. foo
+    20. foo
+        99. foo
+            1. foo
+`;
+        expect(roundTrip(md, 'dfm')).toBe(md);
+    });
 });

--- a/packages/core/src/utils/marked/extensions/__tests__/footnote.spec.ts
+++ b/packages/core/src/utils/marked/extensions/__tests__/footnote.spec.ts
@@ -216,3 +216,152 @@ At vero eos [^foo1]: et accusam.`);
         expect(types).not.toContain('footnote');
     });
 });
+
+// The cases below cover the multi-line footnote-body forms from marktext's
+// markdown-footnotes.spec.js. They exercise the BLOCK_RULE's lazy `:[\s\S]*?`
+// capture plus the "strip leading whitespace / strip leading newlines /
+// de-indent 4-space continuation" cleanup the tokenizer performs.
+describe('marked footnote extension — multi-line bodies', () => {
+    it('body text on the next line via 4-space indent', () => {
+        const tokens = parse(`Lorem [^foo1] ipsum.
+
+[^foo1]:
+    At vero eos et accusam.`);
+        expect(tokens).toEqual([
+            { type: 'paragraph', text: 'Lorem [^foo1] ipsum.' },
+            {
+                type: 'footnote',
+                identifier: 'foo1',
+                children: [{ type: 'paragraph', text: 'At vero eos et accusam.' }],
+            },
+        ]);
+    });
+
+    it('body text on the next paragraph via 4-space indent', () => {
+        const tokens = parse(`Lorem [^foo1] ipsum.
+
+[^foo1]:
+
+    At vero eos et accusam.`);
+        expect(tokens).toEqual([
+            { type: 'paragraph', text: 'Lorem [^foo1] ipsum.' },
+            {
+                type: 'footnote',
+                identifier: 'foo1',
+                children: [{ type: 'paragraph', text: 'At vero eos et accusam.' }],
+            },
+        ]);
+    });
+
+    it('inline body plus continuation paragraph', () => {
+        const tokens = parse(`Lorem [^foo1] ipsum.
+
+[^foo1]: Lorem ipsum dolor sit amet, consetetur sadipscing elitr.
+
+    At vero eos et accusam et justo duo dolores et ea rebum!`);
+        const footnote = tokens.find(t => t.type === 'footnote');
+        expect(footnote?.identifier).toBe('foo1');
+        // Two paragraph children: the inline lead, then the indented
+        // continuation paragraph.
+        const paragraphs = footnote?.children?.filter(t => t.type === 'paragraph') ?? [];
+        expect(paragraphs).toHaveLength(2);
+        expect(paragraphs[0].text).toContain('Lorem ipsum dolor sit amet');
+        expect(paragraphs[1].text).toContain('At vero eos et accusam');
+    });
+
+    it('multi-paragraph body (two paragraphs both 4-space indented)', () => {
+        const tokens = parse(`text[^foo1]
+
+[^foo1]:
+
+    First paragraph of the footnote.
+
+    Second paragraph of the footnote.`);
+        const footnote = tokens.find(t => t.type === 'footnote');
+        expect(footnote?.identifier).toBe('foo1');
+        const paragraphs = footnote?.children?.filter(t => t.type === 'paragraph') ?? [];
+        expect(paragraphs).toHaveLength(2);
+        expect(paragraphs[0].text).toBe('First paragraph of the footnote.');
+        expect(paragraphs[1].text).toBe('Second paragraph of the footnote.');
+    });
+
+    it('list inside a footnote body', () => {
+        const tokens = parse(`text[^foo1]
+
+[^foo1]:
+
+    Lead paragraph.
+
+    - list element 1
+    - list element 2
+    - list element 3`);
+        const footnote = tokens.find(t => t.type === 'footnote');
+        expect(footnote?.identifier).toBe('foo1');
+        const childTypes = footnote?.children?.map(t => t.type) ?? [];
+        expect(childTypes).toContain('paragraph');
+        expect(childTypes).toContain('list');
+    });
+
+    it('fenced code block inside a footnote body', () => {
+        const tokens = parse(`text[^foo1]
+
+[^foo1]:
+
+    Lead paragraph.
+
+    \`\`\`
+    code block content
+    \`\`\`
+
+    Trailing paragraph.`);
+        const footnote = tokens.find(t => t.type === 'footnote');
+        expect(footnote?.identifier).toBe('foo1');
+        const childTypes = footnote?.children?.map(t => t.type) ?? [];
+        // Lead, code, trailing — three children of distinct types.
+        expect(childTypes).toContain('code');
+        expect(childTypes.filter(t => t === 'paragraph')).toHaveLength(2);
+    });
+});
+
+describe('marked footnote extension — termination', () => {
+    it('terminates at a non-indented paragraph (BLOCK_RULE lookahead)', () => {
+        // The footnote body must NOT swallow the trailing non-indented
+        // paragraph. The BLOCK_RULE's `(?=\n *\n {0,3}[^ ]|$)` lookahead
+        // is what enforces this.
+        const tokens = parse(`text[^foo1]
+
+[^foo1]: Inline body of the footnote.
+
+    Continuation that belongs to the footnote.
+
+Trailing paragraph that does NOT belong to the footnote.`);
+        const types = tokens.map(t => t.type);
+        // Exactly one footnote in the stream.
+        expect(types.filter(t => t === 'footnote')).toHaveLength(1);
+        // A separate trailing paragraph outside the footnote.
+        const trailing = tokens.find(
+            t => t.type === 'paragraph'
+                && typeof t.text === 'string'
+                && t.text.startsWith('Trailing paragraph'),
+        );
+        expect(trailing).toBeDefined();
+    });
+
+    it('treats less-than-4-space indented follow-on as outside the footnote', () => {
+        // 2-space indent is below the 4-space continuation threshold — the
+        // follow-on stays as its own (indented but un-belonging) paragraph.
+        const tokens = parse(`text[^foo1]
+
+[^foo1]: Inline body of the footnote.
+
+    Continuation that belongs to the footnote.
+
+  Sed diam nonumy — only 2-space indent, NOT continuation.`);
+        const footnote = tokens.find(t => t.type === 'footnote');
+        expect(footnote).toBeDefined();
+        // The 2-space-indented line is NOT consumed into the footnote
+        // children (the BLOCK_RULE terminates first).
+        const footnoteText = JSON.stringify(footnote);
+        expect(footnoteText).not.toContain('Sed diam nonumy');
+    });
+});

--- a/packages/core/src/utils/marked/extensions/footnote.ts
+++ b/packages/core/src/utils/marked/extensions/footnote.ts
@@ -43,10 +43,16 @@ export default function footnoteExtension(): MarkedExtension {
                     const [raw, identifier, rest] = match;
                     // Strip leading whitespace after the `:` marker (so both
                     // `[^id]: text` and `[^id]:\n    text` start clean) and
-                    // de-indent the 4-space continuation indent.
+                    // de-indent the 4-space continuation indent on every
+                    // line. The first line needs an explicit `^ {4}` strip
+                    // because the per-line de-indent rule below is anchored
+                    // to a preceding `\n`; without that strip an indented-
+                    // continuation body (`[^id]:\n    text`) lexes as an
+                    // indented code block instead of a paragraph.
                     const cleaned = rest
                         .replace(/^[ \t]*/, '')
                         .replace(/^\n+/, '')
+                        .replace(/^ {4}/, '')
                         .replace(/\n {4}(?=\S)/g, '\n')
                         .replace(/\n+$/, '');
 

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/BasicTextFormatting.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/BasicTextFormatting.md
@@ -1,0 +1,36 @@
+## Basic Text Formatting
+
+**Strong** text __Also Strong__
+
+~~strike~~ and `inline code`
+
+<u>under line</u> and 4<sup>3</sup> H<sub>2</sub>O
+
+*this is in italic*  and _so is this_
+
+**this is in bold**  and __so is this__
+
+***this is bold and italic***  and ___so is this___
+
+<b>this will be bold</b>
+
+<i>this will be bold</i>
+
+<s>this is strike through text</s>
+
+So _a_ single _word_ followed _b_y _a_nother
+
+So __a__ single __word__ followed __b__y __a__nother
+
+## Some markdown extensions
+
+This is emoji :man:
+
+This is inline math $a \ne b$
+
+## Paragraph
+
+A two trailing spaces and a new line  
+makes a line break.
+
+Two new lines make a new paragraph.

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/Blockquotes.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/Blockquotes.md
@@ -1,0 +1,42 @@
+# Blockquotes
+
+> Use it if you're quoting a person, a song or whatever.
+
+foo
+
+> Lorem Ipsum is simply dummy text of the printing and typesetting industry.
+> Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book.
+> It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged.
+
+- foo
+- > bar
+- baz
+
+> 1. Lorem Ipsum is simply dummy text 1
+> 2. Lorem Ipsum is simply dummy text 2
+> 3. Lorem Ipsum is simply dummy text 3
+
+> Use it if you're quoting a person, a song or whatever.
+
+> You can use *italic* or lists inside them also.
+
+## Failing Tests
+
+```
+> You can use *italic* or lists inside them also.
+And just like with other paragraphs,
+all of these lines are still
+part of the blockquote, even without the > character in front.
+
+To end the blockquote, just put a blank line before the following
+paragraph.
+```
+
+```
+* foo
+
+  > This is a blockquote
+  > inside a list item.
+
+* bar
+```

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/CodeBlocks.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/CodeBlocks.md
@@ -1,0 +1,27 @@
+# Code Blocks
+
+## Indent Code Block
+
+    This line won't *have any markdown* formatting applied.
+    I can even write <b>HTML</b> and it will show up as text.
+    This is great for showing program source code, or HTML or even
+    Markdown. <b>this won't show up as HTML</b> but
+    exactly <i>as you see it in this text file</i>.
+
+Within a paragraph, you can use backquotes to do the same thing.
+`This won't be *italic* or **bold** at all.`
+
+## Fence Code Block
+
+```cpp
+#include <iostream>
+
+int main(int argc, const char* argv[]) {
+  std::cout << "C++ code block test" << std::endl;
+  return 0;
+}
+```
+
+```
+This is a code block without language identifier.
+```

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/Escapes.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/Escapes.md
@@ -1,0 +1,17 @@
+# Escapes
+
+\# This isn't a heading
+
+\*this isn't in italic\*  and \_so is this\_
+
+\*\*this isn't in bold\*\*  and \_\_so is this\_\_
+
+\`\`\`
+This isn't a code block without language identifier.
+\`\`\`
+
+\$ You can also escape math \$.
+
+\$\$
+This isn't a math block.
+\$\$

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/Headings.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/Headings.md
@@ -1,0 +1,68 @@
+# Headings
+
+## Setext heading
+
+This is a huge header
+===
+
+this is a smaller header
+---
+
+header
+---
+
+This is a huge header
+==================
+
+this is a smaller header
+------------------
+
+## Atx heading
+
+## ATX Headings
+
+# foo
+
+bar
+
+## foo
+
+bar
+
+### foo
+
+bar
+
+#### foo
+
+bar
+
+##### foo
+
+bar
+
+###### foo
+
+bar
+
+####### This isn't a heading
+
+bar
+
+#5 This isn't a heading
+
+#This isn't a heading
+
+## Horizontal Rule
+
+---
+
+foo
+
+---
+
+bar
+
+## Horizontal Rule
+
+   - - -  - --   --- --- ----

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/Images.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/Images.md
@@ -1,0 +1,3 @@
+# Images
+
+![alternate text](https://raw.githubusercontent.com/marktext/marktext/master/resources/icons/128x128/marktext.png)

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/Links.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/Links.md
@@ -1,0 +1,24 @@
+# Links
+
+[title](http://127.0.0.1)
+
+[title with spaces](https://localhost)
+
+- [title](http://127.0.0.1)
+
+- [title with spaces](https://localhost)
+
+- [ ] [title](http://127.0.0.1)
+
+- [x] [title with spaces](https://localhost)
+
+## Reference Links
+
+You can also put the [link URL][1] below the current paragraph like [this][2].
+
+[1]: http://url.local
+[2]: http://another.url
+
+Or you can use a [shortcut][] reference, which links the text "shortcut" to the link named "[shortcut]" on the next paragraph.
+
+[shortcut]: http://goes/with/the/link/name/text

--- a/packages/core/test/spec/fixtures/marktext-round-trip/common/Lists.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/common/Lists.md
@@ -1,0 +1,179 @@
+# Lists
+
+* an asterisk starts an unordered list
+* and this is another item in the list
+* and this is another item in the list
+
+To start an ordered list, write this:
+
+<!-- Strange indentation -->
+
+1. this starts a list *with* numbers
+
+2. this will show as number "2"
+
+3. this will show as number "3."
+
+4. any number, +, -, or * will keep the list going.
+   
+   * just indent by 4 spaces (or tab) to make a sub-list
+     1. keep indenting for more sub lists
+   
+   * here i'm back to the second level
+
+---
+
+1) this starts a list *with* numbers
+2) this will show as number "2"
+3) this will show as number "3"
+
+---
+
+- foo
+  - bar
+    - baz
+      - boo
+
+---
+
+- a
+  - b
+    - c
+      - d
+        - e
+      - f
+    - g
+  - h
+- i
+
+---
+
+- foo
+- 
+- bar
+
+---
+
+**TODO:** Empty comments should not be displayed as HTML in preview mode because they may be used to separate consecutive lists of the same type (CM Example 270).
+
+- foo
+- bar
+
+<!-- -->
+
+- baz
+- bim
+
+---
+
+-one
+
+2.two
+
+---
+
+- foo
+- bar
++ baz
+* foobar
+* qux
+
+---
+
+1. foo
+2. bar
+4) baz
+
+---
+
+1. foo
+2. bar
+1) baz
+
+---
+
+- foo
+- bar
++ foobar
++ baz
+
+---
+
+- foo
+- bar
+* foobar
+* baz
+
+---
+
+- foo
+- bar
+* foobar
+* baz
++ qux
++ quux
+
+---
+
+- foo
+- bar
+1. foobar
+2. baz
+
+---
+
+1. foo
+2. bar
+- foobar
+- baz
+
+---
+
+1. foo
+2. bar
+1) foobar
+2) baz
+
+---
+
+- foo
+- 
+- bar
+
+## Failing Tests
+
+```
+1. this starts a list *with* numbers
++  this will show as number "2"
+*  this will show as number "3."
+9. any number, +, -, or * will keep the list going.
+    * just indent by 4 spaces (or tab) to make a sub-list
+        1. keep indenting for more sub lists
+    * here i'm back to the second level
+```
+
+```
+1. this starts a list *with* numbers
++  this will show as number "2"
+*  this will show as number "3."
+9. any number, +, -, or * will keep the list going.
+  * just indent by 2 spaces to make a sub-list
+    1. keep indenting for more sub lists
+  * here i'm back to the second level
+```
+
+```
+CommonMark Example 266
+
+Foo
+- bar
+- baz
+```
+
+Issue `-` is replaced by `- `:
+
+```
+- foo
+-
+- bar
+```

--- a/packages/core/test/spec/fixtures/marktext-round-trip/gfm/BasicTextFormatting.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/gfm/BasicTextFormatting.md
@@ -1,0 +1,5 @@
+# Basic Text Formatting
+
+~~this is strike through text~~
+
+\~\~and this not\~\~

--- a/packages/core/test/spec/fixtures/marktext-round-trip/gfm/Lists.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/gfm/Lists.md
@@ -1,0 +1,19 @@
+# GFM Lists
+
+To start a check list, write this:
+
+- [ ] this is not checked
+- [ ] this is too
+- [x] but this is checked
+
+---
+
+* [x] this is checked
+* [ ] this is not checked
+* [x] but this is checked
+
+---
+
++ [ ] this is not checked
++ [ ] this is too
++ [x] but this is checked

--- a/packages/core/test/spec/fixtures/marktext-round-trip/gfm/Tables.md
+++ b/packages/core/test/spec/fixtures/marktext-round-trip/gfm/Tables.md
@@ -1,0 +1,20 @@
+# Tables
+
+| First Header   | Second Header    |
+| -------------- | ---------------- |
+| Co`nten`t Cell | Content Cell     |
+| Content Cell   | **Content Cell** |
+
+| First \| Header | Second Header   |
+| --------------- | --------------- |
+| Content Cell    | Content Cell    |
+| Content \|Cell  | Content \| Cell |
+
+## Failing Tests
+
+```
+First Header | Second Header
+------------ | -------------
+Content Cell | Content Cell
+Content Cell | Content Cell
+```

--- a/packages/core/test/spec/roundTrip.spec.ts
+++ b/packages/core/test/spec/roundTrip.spec.ts
@@ -2,6 +2,7 @@
 
 import fs from 'node:fs';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 import { MarkdownToState } from '../../src/state/markdownToState';
 import StateToMarkdown from '../../src/state/stateToMarkdown';
@@ -16,8 +17,12 @@ import StateToMarkdown from '../../src/state/stateToMarkdown';
 // normalises to LF internally, so we keep just the LF variant here. CRLF
 // round-trip is exercised by `clipboard/` paste handling instead.
 
-const fixturesDir = path.resolve(
-    path.dirname(new URL(import.meta.url).pathname),
+// Use `fileURLToPath` rather than `new URL(...).pathname` — the latter
+// returns a URL pathname (POSIX-only, percent-encoded for unusual chars),
+// which would break fixture resolution on Windows or when the worktree
+// path contains anything that needs URL-encoding (`@`, spaces, etc.).
+const fixturesDir = path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
     'fixtures',
     'marktext-round-trip',
 );
@@ -57,17 +62,18 @@ function roundTrip(markdown: string): string {
 }
 
 // Round-trip is rarely byte-for-byte identical for non-trivial markdown:
-// the serializer canonicalises whitespace (single trailing newline, no
-// trailing whitespace on lines, normalised list-item indentation). To
-// avoid asserting against those incidental choices, both sides are
-// passed through this normaliser before comparison — anything the
-// serializer produces twice in a row is by definition stable.
+// the serializer canonicalises a trailing newline and the input may use
+// CRLF while the serializer always emits LF. To avoid asserting against
+// those incidental choices, both sides are passed through this normaliser
+// before comparison.
+//
+// We deliberately do NOT strip trailing whitespace per line: two trailing
+// spaces are a CommonMark §6.7 hard-line-break marker, so collapsing them
+// would mask a real round-trip instability. If the serializer ever emits
+// different trailing whitespace on a re-pass, the test should report it.
 function normalise(md: string): string {
     return md
         .replace(/\r\n?/g, '\n')
-        .split('\n')
-        .map(line => line.replace(/[ \t]+$/, ''))
-        .join('\n')
         .replace(/\n+$/, '');
 }
 

--- a/packages/core/test/spec/roundTrip.spec.ts
+++ b/packages/core/test/spec/roundTrip.spec.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { MarkdownToState } from '../../src/state/markdownToState';
+import StateToMarkdown from '../../src/state/stateToMarkdown';
+
+// Backported from marktext `test/unit/specs/markdown-basic.spec.js`. Each
+// fixture is parsed to the new muya state tree and re-serialised; the
+// expectation is that the round trip is the identity (modulo a trailing
+// newline — the source files were saved with no trailing newline, but the
+// serializer always appends one).
+//
+// The original test ran each fixture twice (LF / CRLF). The new muya
+// normalises to LF internally, so we keep just the LF variant here. CRLF
+// round-trip is exercised by `clipboard/` paste handling instead.
+
+const fixturesDir = path.resolve(
+    path.dirname(new URL(import.meta.url).pathname),
+    'fixtures',
+    'marktext-round-trip',
+);
+
+interface IFixture {
+    label: string;
+    file: string;
+}
+
+const fixtures: IFixture[] = [
+    { label: 'common / Basic Text Formatting', file: 'common/BasicTextFormatting.md' },
+    { label: 'common / Blockquotes', file: 'common/Blockquotes.md' },
+    { label: 'common / Code Blocks', file: 'common/CodeBlocks.md' },
+    { label: 'common / Escapes', file: 'common/Escapes.md' },
+    { label: 'common / Headings', file: 'common/Headings.md' },
+    { label: 'common / Images', file: 'common/Images.md' },
+    { label: 'common / Links', file: 'common/Links.md' },
+    { label: 'common / Lists', file: 'common/Lists.md' },
+    { label: 'GFM / Basic Text Formatting', file: 'gfm/BasicTextFormatting.md' },
+    { label: 'GFM / Lists', file: 'gfm/Lists.md' },
+    { label: 'GFM / Tables', file: 'gfm/Tables.md' },
+];
+
+function readFixture(rel: string): string {
+    return fs.readFileSync(path.join(fixturesDir, rel), 'utf8');
+}
+
+function roundTrip(markdown: string): string {
+    const states = new MarkdownToState({
+        footnote: false,
+        math: true,
+        isGitlabCompatibilityEnabled: true,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: true,
+    }).generate(markdown);
+    return new StateToMarkdown({ listIndentation: 1 }).generate(states);
+}
+
+// Round-trip is rarely byte-for-byte identical for non-trivial markdown:
+// the serializer canonicalises whitespace (single trailing newline, no
+// trailing whitespace on lines, normalised list-item indentation). To
+// avoid asserting against those incidental choices, both sides are
+// passed through this normaliser before comparison — anything the
+// serializer produces twice in a row is by definition stable.
+function normalise(md: string): string {
+    return md
+        .replace(/\r\n?/g, '\n')
+        .split('\n')
+        .map(line => line.replace(/[ \t]+$/, ''))
+        .join('\n')
+        .replace(/\n+$/, '');
+}
+
+function isStableUnderRoundTrip(markdown: string): boolean {
+    const once = roundTrip(markdown);
+    const twice = roundTrip(once);
+    return normalise(once) === normalise(twice);
+}
+
+describe('marktext markdown-basic round-trip', () => {
+    it.each(fixtures)(
+        `$label is stable under md → state → md`,
+        ({ file }) => {
+            const original = readFixture(file);
+            // The strict assertion is that the round trip converges: a
+            // second pass returns the same string the first pass produced.
+            // Strict byte-for-byte equality against the original is too
+            // strict (and was already non-deterministic in marktext for
+            // most of these fixtures — list indentation differs from
+            // ExportMarkdown's canonical choice).
+            expect(isStableUnderRoundTrip(original)).toBe(true);
+        },
+    );
+
+    // The 4 fixtures whose first-pass output equals the original verbatim
+    // also satisfy the stricter "identity" round-trip. We assert this
+    // separately so a regression that breaks identity is visible.
+    const identityFixtures: IFixture[] = [
+        { label: 'common / Images', file: 'common/Images.md' },
+        { label: 'common / Escapes', file: 'common/Escapes.md' },
+        { label: 'GFM / Basic Text Formatting', file: 'gfm/BasicTextFormatting.md' },
+        { label: 'GFM / Tables', file: 'gfm/Tables.md' },
+    ];
+
+    it.each(identityFixtures)(
+        `$label survives md → state → md verbatim (modulo trailing newline)`,
+        ({ file }) => {
+            const original = readFixture(file);
+            const output = roundTrip(original);
+            expect(normalise(output)).toBe(normalise(original));
+        },
+    );
+});


### PR DESCRIPTION
## Summary

PR-6b from the marktext muya → @muyajs/core migration plan. Three test backports plus one real parser bug fix surfaced via the new tests.

### Backports

1. **footnote (`utils/marked/extensions/__tests__/footnote.spec.ts`)** — picks up the multi-line body cases that PR-2a's initial port skipped. Backports 8 cases from marktext `test/unit/specs/markdown-footnotes.spec.js`: body on next line / next paragraph (via 4-space indent), inline body + continuation paragraph, multi-paragraph body, list inside footnote, fenced code block inside footnote, termination at non-indented paragraph, termination at less-than-4-space indented follow-on. 13 → 21 tests.

2. **markdown-basic round-trip (`test/spec/roundTrip.spec.ts`)** — new spec. Copies 11 fixtures from marktext `test/unit/data/{common,gfm}/*.md` into `test/spec/fixtures/marktext-round-trip/`. Two assertions per applicable fixture: round-trip stability (a second pass produces the same string) and, for the 4 fixtures that survive verbatim, strict identity. CRLF variant skipped — new muya normalises to LF internally; CRLF is exercised by clipboard tests instead. 15 new tests.

3. **list-indentation (`state/__tests__/listSerialization.spec.ts`)** — adds the missing `dfm` (Daring Fireball Markdown) strategy round trip. The 1/2/3/4-space strategies were already covered by PR-2b. 11 → 12 tests.

### Incidental parser fix

5 of the 8 new footnote cases initially failed RED — all the same root cause: `footnote.ts`'s cleanup runs `replace(/\n {4}(?=\S)/g, '\n')` to de-indent continuation lines, but the *first* line of an indented body kept its 4-space prefix. marked then lexed it as an indented code block instead of a paragraph. Added one extra `replace(/^ {4}/, '')` to the cleanup pipeline; all 8 cases now pass and match marktext's pre-marked-v16 lexer.js output. No other footnote behaviour changes; the existing 13 tests still pass.

### Counts

| | Before | After |
|---|---|---|
| Unit tests | 215 | 224 (+9) |
| Spec tests | 1332 | 1347 (+15) |

### Test plan

- [x] `pnpm --filter @muyajs/core test` — 224 / 224 pass
- [x] `pnpm --filter @muyajs/core test:spec` — 1347 / 1347 pass (CommonMark/GFM baseline unchanged: CM 572/652 87.7%, GFM 580/672 86.3%)
- [x] `pnpm --filter @muyajs/core lint:types` — clean
- [x] `pnpm check-circular` — no circular dependencies
- [x] `pnpm lint` — 0 errors (19 pre-existing complexity warnings unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)