### PR TITLE
chore: P3 tidy + skipped tags (PR-9 / PR-12)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -115,8 +115,8 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | Hash | 类型 | 说明 | 状态 |
 |---|---|---|---|
 | 7377de3c | feat | footnote 完整链路 | `pending` |
-| ab97336e | feat | highlight 菜单 | `pending` |
-| 1ef0d016 | feat | linkTools unlink/jump | `pending` |
+| ab97336e | feat | highlight 菜单 | PR-9 | `test-only`（`<mark>` 已在 `inlineFormatToolbar/config.ts` 含 `type: 'mark'` + 快捷键 `⇧+Cmd+H`；3 个防御测试锁住 7 个核心 inline-format type + icon 不被回退） |
+| 1ef0d016 | feat | linkTools unlink/jump | PR-9 | `test-only`（subscriber + `selectItem` dispatcher 已就位但 `muya-link-tools` 暂无 emitter；删 `@ts-nocheck` 补类型 + 2 个防御测试锁住 unlink / jump 分支） |
 | cb25b3d4 | feat | linkTools 支持 `<a>` 与 ref link | `pending` |
 | 141d25d8 | feat | 粘贴链接抓页面标题 | PR-4c | `fixed`（`res.json()`→`res.text()`，5 个测试） |
 | d26f5092 | feat | image resize + inline/block 切换 | `pending` |
@@ -127,9 +127,11 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 47cb2bbe | feat | indent code block | `verified-not-applicable`（上游核心是"4-space 自动转换"路径，新仓 `packages/core/src/block/base/format.ts:53` regex `^( {4,})` + `_convertToIndentedCodeBlock()` (`:1163-1211`) 已实现；UI 上无显式入口，但上游也没有） |
 | 7aa0d1bf | feat | code block 复制按钮 | `verified-not-applicable`（新仓 `packages/core/src/block/commonMark/codeBlock/code.ts:15-41 renderCopyButton` + `:88-101` 点击经 `editor.clipboard.copy('copyCodeContent', ...)`；`.mu-code-copy` 样式见 `blockSyntax.css`） |
 | a028a7c2 | feat | code block 行号 | PR-5a | `fixed`（`codeBlockLineNumbers` 选项默认关闭；`renderLineNumbersInnerHTML` + `.mu-line-numbers-rows` 渲染；仅 `code-block` 容器接入，frontmatter / math / diagram / html 不挂；10 个回归测试） |
-| ef9fe756 | feat | underline 格式 | `pending` |
-| 81af43be | feat | quick insert hint 隐藏 | `pending` |
-| c0c8ea4b | feat | 打开外链 / 本地 md | `pending` |
+| ef9fe756 | feat | underline 格式 | PR-9 | `test-only`（`<u>` 已在 `inlineFormatToolbar/config.ts` 含 `type: 'u'` + 快捷键 `Cmd+U`；由 `ab97336e` 同一份 7-type 防御测试覆盖） |
+| 81af43be | feat | quick insert hint 隐藏 | PR-9 | `test-only`（`muya.ts::getContainer` 已读 `options.hideQuickInsertHint` 控制 `mu-show-quick-insert-hint` class；3 个防御测试锁住 默认 / false / true 三态） |
+| c0c8ea4b | feat | 打开外链 / 本地 md | PR-12 | `skipped`（Electron `shell.openExternal` 路径，跨 SDK 边界，应用层做） |
+| afe68891 | feat | SM.MS 上传删除链接 | PR-12 | `skipped`（uploader 专属，新仓不集成 uploader） |
+| 435dca74 | feat | Unsplash 搜图 | PR-12 | `skipped`（网络依赖 + API key + UI 重大改动，对纯 markdown 库过重） |
 | f3b53427 | feat | 跳光标到末尾再格式化 | `pending` |
 | efd38644 | feat | 长 footnote 编号 | `pending` |
 | 318bfc6a / fc89d04a / 37b96c88 | feat | footnote 系列 | `pending` |

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -115,8 +115,8 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | Hash | 类型 | 说明 | 状态 |
 |---|---|---|---|
 | 7377de3c | feat | footnote 完整链路 | `pending` |
-| ab97336e | feat | highlight 菜单 | PR-9 | `test-only`（`<mark>` 已在 `inlineFormatToolbar/config.ts` 含 `type: 'mark'` + 快捷键 `⇧+Cmd+H`；3 个防御测试锁住 7 个核心 inline-format type + icon 不被回退） |
-| 1ef0d016 | feat | linkTools unlink/jump | PR-9 | `test-only`（subscriber + `selectItem` dispatcher 已就位但 `muya-link-tools` 暂无 emitter；删 `@ts-nocheck` 补类型 + 2 个防御测试锁住 unlink / jump 分支） |
+| ab97336e | feat | highlight 菜单 | PR-9 `test-only`（`<mark>` 已在 `inlineFormatToolbar/config.ts` 含 `type: 'mark'` + 快捷键 `⇧+Cmd+H`；3 个防御测试锁住 7 个核心 inline-format type + icon 不被回退） |
+| 1ef0d016 | feat | linkTools unlink/jump | PR-9 `test-only`（subscriber + `selectItem` dispatcher 已就位但 `muya-link-tools` 暂无 emitter；删 `@ts-nocheck` 补类型 + 2 个防御测试锁住 unlink / jump 分支） |
 | cb25b3d4 | feat | linkTools 支持 `<a>` 与 ref link | `pending` |
 | 141d25d8 | feat | 粘贴链接抓页面标题 | PR-4c | `fixed`（`res.json()`→`res.text()`，5 个测试） |
 | d26f5092 | feat | image resize + inline/block 切换 | `pending` |
@@ -127,11 +127,11 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 47cb2bbe | feat | indent code block | `verified-not-applicable`（上游核心是"4-space 自动转换"路径，新仓 `packages/core/src/block/base/format.ts:53` regex `^( {4,})` + `_convertToIndentedCodeBlock()` (`:1163-1211`) 已实现；UI 上无显式入口，但上游也没有） |
 | 7aa0d1bf | feat | code block 复制按钮 | `verified-not-applicable`（新仓 `packages/core/src/block/commonMark/codeBlock/code.ts:15-41 renderCopyButton` + `:88-101` 点击经 `editor.clipboard.copy('copyCodeContent', ...)`；`.mu-code-copy` 样式见 `blockSyntax.css`） |
 | a028a7c2 | feat | code block 行号 | PR-5a | `fixed`（`codeBlockLineNumbers` 选项默认关闭；`renderLineNumbersInnerHTML` + `.mu-line-numbers-rows` 渲染；仅 `code-block` 容器接入，frontmatter / math / diagram / html 不挂；10 个回归测试） |
-| ef9fe756 | feat | underline 格式 | PR-9 | `test-only`（`<u>` 已在 `inlineFormatToolbar/config.ts` 含 `type: 'u'` + 快捷键 `Cmd+U`；由 `ab97336e` 同一份 7-type 防御测试覆盖） |
-| 81af43be | feat | quick insert hint 隐藏 | PR-9 | `test-only`（`muya.ts::getContainer` 已读 `options.hideQuickInsertHint` 控制 `mu-show-quick-insert-hint` class；3 个防御测试锁住 默认 / false / true 三态） |
-| c0c8ea4b | feat | 打开外链 / 本地 md | PR-12 | `skipped`（Electron `shell.openExternal` 路径，跨 SDK 边界，应用层做） |
-| afe68891 | feat | SM.MS 上传删除链接 | PR-12 | `skipped`（uploader 专属，新仓不集成 uploader） |
-| 435dca74 | feat | Unsplash 搜图 | PR-12 | `skipped`（网络依赖 + API key + UI 重大改动，对纯 markdown 库过重） |
+| ef9fe756 | feat | underline 格式 | PR-9 `test-only`（`<u>` 已在 `inlineFormatToolbar/config.ts` 含 `type: 'u'` + 快捷键 `Cmd+U`；由 `ab97336e` 同一份 7-type 防御测试覆盖） |
+| 81af43be | feat | quick insert hint 隐藏 | PR-9 `test-only`（`muya.ts::getContainer` 已读 `options.hideQuickInsertHint` 控制 `mu-show-quick-insert-hint` class；3 个防御测试锁住 默认 / false / true 三态） |
+| c0c8ea4b | feat | 打开外链 / 本地 md | PR-12 `skipped`（Electron `shell.openExternal` 路径，跨 SDK 边界，应用层做） |
+| afe68891 | feat | SM.MS 上传删除链接 | PR-12 `skipped`（uploader 专属，新仓不集成 uploader） |
+| 435dca74 | feat | Unsplash 搜图 | PR-12 `skipped`（网络依赖 + API key + UI 重大改动，对纯 markdown 库过重） |
 | f3b53427 | feat | 跳光标到末尾再格式化 | `pending` |
 | efd38644 | feat | 长 footnote 编号 | `pending` |
 | 318bfc6a / fc89d04a / 37b96c88 | feat | footnote 系列 | `pending` |

--- a/packages/core/src/ui/inlineFormatToolbar/__tests__/config.spec.ts
+++ b/packages/core/src/ui/inlineFormatToolbar/__tests__/config.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import icons from '../config';
+
+// P3 defensive lock for marktext `ab97336e` (highlight `<mark>`) and
+// `ef9fe756` (underline `<u>`). These shortcuts already shipped in muya
+// alongside the other six inline format types, but nothing in the test
+// suite asserts that they stay wired into the toolbar config — quietly
+// dropping an entry would silently delete the user-visible button.
+//
+// The toolbar reads `config.ts` and renders one button per entry; the
+// `type` string is the same key the formatHandler dispatches on, so a
+// regression here would break both the UI surface and the keyboard
+// shortcut path. This file locks the seven inline-format types plus
+// their `icon` field so a regression has to be deliberate.
+//
+// Kept narrow: we do not lock tooltip/shortcut text (which is i18n /
+// platform-dependent) or the `image`/`inline_math`/`clear` entries
+// (which are out of scope for the highlight + underline backports).
+
+const REQUIRED_TYPES = [
+    'strong',
+    'em',
+    'u',
+    'del',
+    'mark',
+    'inline_code',
+    'link',
+] as const;
+
+describe('inlineFormatToolbar config — required inline format types', () => {
+    it('exports an array of icon entries', () => {
+        expect(Array.isArray(icons)).toBe(true);
+        expect(icons.length).toBeGreaterThanOrEqual(REQUIRED_TYPES.length);
+    });
+
+    it.each(REQUIRED_TYPES)('contains an entry for type %s with an icon', (type) => {
+        const entry = icons.find(i => i.type === type);
+        expect(entry, `missing config entry for type=${type}`).toBeTruthy();
+        expect(entry!.icon, `type=${type} entry has no icon`).toBeTruthy();
+    });
+
+    it('does not duplicate any required type', () => {
+        for (const type of REQUIRED_TYPES) {
+            const matches = icons.filter(i => i.type === type);
+            expect(matches.length, `type=${type} appears ${matches.length} times`).toBe(1);
+        }
+    });
+});

--- a/packages/core/src/ui/linkTools/__tests__/linkTools.spec.ts
+++ b/packages/core/src/ui/linkTools/__tests__/linkTools.spec.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import type { Muya } from '../../../muya';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import EventCenter from '../../../event';
 import LinkTools from '../index';
 
@@ -16,19 +16,38 @@ import LinkTools from '../index';
 // then poke `selectItem` directly to verify each branch dispatches to
 // the right collaborator.
 
-function makeFakeMuya(unlink: (info: unknown) => void): Muya {
+interface ITestSession {
+    muya: Muya;
+    tools: LinkTools;
+    domNode: HTMLElement;
+}
+
+const sessions: ITestSession[] = [];
+
+function makeFakeMuya(unlink: (info: unknown) => void): { muya: Muya; domNode: HTMLElement } {
     const eventCenter = new EventCenter();
     const domNode = document.createElement('div');
     document.body.appendChild(domNode);
-    // The constructor of LinkTools chains through BaseFloat.listen(), which
-    // attaches a scroll handler to `domNode.parentElement`. document.body is
-    // the parent so that's fine here.
-    const fakeMuya = {
+    // BaseFloat.listen() attaches a scroll handler to `domNode.parentElement`,
+    // so `domNode` needs a parent — `document.body` here.
+    const muya = {
         eventCenter,
         domNode,
         contentState: { unlink },
     } as unknown as Muya;
-    return fakeMuya;
+    return { muya, domNode };
+}
+
+interface ILinkToolsTestOptions {
+    jumpClick?: (linkInfo: unknown) => void;
+}
+
+function bootLinkTools(unlink: (info: unknown) => void, options: ILinkToolsTestOptions = {}): ITestSession {
+    const { muya, domNode } = makeFakeMuya(unlink);
+    const tools = new LinkTools(muya, options);
+    const session = { muya, tools, domNode };
+    sessions.push(session);
+    return session;
 }
 
 function makeFakeEvent() {
@@ -38,11 +57,23 @@ function makeFakeEvent() {
     } as unknown as Event;
 }
 
+afterEach(() => {
+    // Tear each session down: detach DOM listeners attached via EventCenter,
+    // destroy the floating-tool DOM (resize observers + floatBox), and
+    // unmount the host node from document.body. This prevents listener /
+    // node leakage across tests in the same worker.
+    while (sessions.length) {
+        const { muya, tools, domNode } = sessions.pop()!;
+        tools.destroy();
+        muya.eventCenter.detachAllDomEvents();
+        domNode.remove();
+    }
+});
+
 describe('linkTools.selectItem — dispatches to contentState / jumpClick', () => {
     it('unlink: routes to muya.contentState.unlink with the captured linkInfo', () => {
         const unlink = vi.fn();
-        const muya = makeFakeMuya(unlink);
-        const tools = new LinkTools(muya);
+        const { tools } = bootLinkTools(unlink);
 
         const linkInfo = { href: 'https://example.com', text: 'hi' };
         tools.linkInfo = linkInfo;
@@ -56,8 +87,7 @@ describe('linkTools.selectItem — dispatches to contentState / jumpClick', () =
     it('jump: routes to options.jumpClick with the captured linkInfo', () => {
         const unlink = vi.fn();
         const jumpClick = vi.fn();
-        const muya = makeFakeMuya(unlink);
-        const tools = new LinkTools(muya, { jumpClick });
+        const { tools } = bootLinkTools(unlink, { jumpClick });
 
         const linkInfo = { href: 'https://example.com' };
         tools.linkInfo = linkInfo;

--- a/packages/core/src/ui/linkTools/__tests__/linkTools.spec.ts
+++ b/packages/core/src/ui/linkTools/__tests__/linkTools.spec.ts
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+import type { Muya } from '../../../muya';
+import { describe, expect, it, vi } from 'vitest';
+import EventCenter from '../../../event';
+import LinkTools from '../index';
+
+// P3 defensive lock for marktext `1ef0d016` (link tools — unlink / jump).
+// The new linkTools subscriber + `selectItem` dispatcher is fully staged
+// in muya but there's no emitter for `muya-link-tools` yet, so neither
+// the unlink path nor the jump path is exercised end-to-end. Without a
+// test pinning the dispatch, a future refactor (e.g. renaming `unlink` /
+// `jumpClick`, or swapping the switch on `item.type`) would silently
+// regress the structure when the wiring is finally completed.
+//
+// These tests stub the floating-tool DOM surface and the eventCenter,
+// then poke `selectItem` directly to verify each branch dispatches to
+// the right collaborator.
+
+function makeFakeMuya(unlink: (info: unknown) => void): Muya {
+    const eventCenter = new EventCenter();
+    const domNode = document.createElement('div');
+    document.body.appendChild(domNode);
+    // The constructor of LinkTools chains through BaseFloat.listen(), which
+    // attaches a scroll handler to `domNode.parentElement`. document.body is
+    // the parent so that's fine here.
+    const fakeMuya = {
+        eventCenter,
+        domNode,
+        contentState: { unlink },
+    } as unknown as Muya;
+    return fakeMuya;
+}
+
+function makeFakeEvent() {
+    return {
+        preventDefault: vi.fn(),
+        stopPropagation: vi.fn(),
+    } as unknown as Event;
+}
+
+describe('linkTools.selectItem — dispatches to contentState / jumpClick', () => {
+    it('unlink: routes to muya.contentState.unlink with the captured linkInfo', () => {
+        const unlink = vi.fn();
+        const muya = makeFakeMuya(unlink);
+        const tools = new LinkTools(muya);
+
+        const linkInfo = { href: 'https://example.com', text: 'hi' };
+        tools.linkInfo = linkInfo;
+
+        tools.selectItem(makeFakeEvent(), { type: 'unlink', icon: '' });
+
+        expect(unlink).toHaveBeenCalledTimes(1);
+        expect(unlink).toHaveBeenCalledWith(linkInfo);
+    });
+
+    it('jump: routes to options.jumpClick with the captured linkInfo', () => {
+        const unlink = vi.fn();
+        const jumpClick = vi.fn();
+        const muya = makeFakeMuya(unlink);
+        const tools = new LinkTools(muya, { jumpClick });
+
+        const linkInfo = { href: 'https://example.com' };
+        tools.linkInfo = linkInfo;
+
+        tools.selectItem(makeFakeEvent(), { type: 'jump', icon: '' });
+
+        expect(jumpClick).toHaveBeenCalledTimes(1);
+        expect(jumpClick).toHaveBeenCalledWith(linkInfo);
+        // The unlink path must not fire on jump.
+        expect(unlink).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/ui/linkTools/index.ts
+++ b/packages/core/src/ui/linkTools/index.ts
@@ -1,11 +1,38 @@
-// eslint-disable-next-line ts/ban-ts-comment
-// @ts-nocheck
-
+import type { VNode } from 'snabbdom';
+import type { Muya } from '../../muya';
+import type { IBaseOptions } from '../types';
 import { h, patch } from '../../utils/snabbdom';
 import BaseFloat from '../baseFloat';
-import icons from './config';
+import iconsConfig from './config';
 
 import './index.css';
+
+type LinkToolIcon = typeof iconsConfig[number];
+
+interface ILinkInfo {
+    href?: string;
+    text?: string;
+    [key: string]: unknown;
+}
+
+interface ILinkToolsOptions extends IBaseOptions {
+    jumpClick?: (linkInfo: ILinkInfo | null) => void;
+}
+
+interface ILinkToolsEventPayload {
+    reference: HTMLElement | null;
+    linkInfo?: ILinkInfo | null;
+}
+
+// `muya.contentState` is the marktext-era ContentState facade; the new Muya
+// only stages it (no emitter for `muya-link-tools` yet either). Cast at the
+// boundary so the call site keeps compiling without lying about the Muya
+// surface globally.
+type IMuyaWithContentState = Muya & {
+    contentState?: {
+        unlink: (linkInfo: ILinkInfo | null) => void;
+    };
+};
 
 const defaultOptions = {
     placement: 'bottom' as const,
@@ -20,26 +47,29 @@ const defaultOptions = {
 class LinkTools extends BaseFloat {
     static pluginName = 'linkTools';
 
-    constructor(muya, options = {}) {
+    public override options: ILinkToolsOptions;
+    public oldVNode: VNode | null = null;
+    public linkInfo: ILinkInfo | null = null;
+    public icons: LinkToolIcon[] = iconsConfig;
+    public hideTimer: ReturnType<typeof setTimeout> | null = null;
+    public linkContainer: HTMLElement;
+
+    constructor(muya: Muya, options: Partial<ILinkToolsOptions> = {}) {
         const name = 'mu-link-tools';
-        const opts = Object.assign({}, defaultOptions, options);
+        const opts: ILinkToolsOptions = Object.assign({}, defaultOptions, options);
         super(muya, name, opts);
-        this.oldVNode = null;
-        this.linkInfo = null;
         this.options = opts;
-        this.icons = icons;
-        this.hideTimer = null;
         const linkContainer = (this.linkContainer = document.createElement('div'));
-        this.container.appendChild(linkContainer);
+        this.container!.appendChild(linkContainer);
         this.listen();
     }
 
-    listen() {
+    override listen() {
         const { eventCenter } = this.muya;
         super.listen();
-        eventCenter.subscribe('muya-link-tools', ({ reference, linkInfo }) => {
+        eventCenter.subscribe('muya-link-tools', ({ reference, linkInfo }: ILinkToolsEventPayload) => {
             if (reference) {
-                this.linkInfo = linkInfo;
+                this.linkInfo = linkInfo ?? null;
                 setTimeout(() => {
                     this.show(reference);
                     this.render();
@@ -64,15 +94,15 @@ class LinkTools extends BaseFloat {
             this.hide();
         };
 
-        eventCenter.attachDOMEvent(this.container, 'mouseover', mouseOverHandler);
-        eventCenter.attachDOMEvent(this.container, 'mouseleave', mouseOutHandler);
+        eventCenter.attachDOMEvent(this.container!, 'mouseover', mouseOverHandler);
+        eventCenter.attachDOMEvent(this.container!, 'mouseleave', mouseOutHandler);
     }
 
     render() {
         const { icons, oldVNode, linkContainer } = this;
         const children = icons.map((i) => {
-            let icon;
-            let iconWrapperSelector;
+            let icon: VNode | undefined;
+            let iconWrapperSelector: string | undefined;
             if (i.icon) {
                 // SVG icon Asset
                 iconWrapperSelector = 'div.icon-wrapper';
@@ -90,14 +120,14 @@ class LinkTools extends BaseFloat {
                     ),
                 );
             }
-            const iconWrapper = h(iconWrapperSelector, icon);
+            const iconWrapper = h(iconWrapperSelector ?? 'div.icon-wrapper', icon);
             const itemSelector = `li.item.${i.type}`;
 
             return h(
                 itemSelector,
                 {
                     on: {
-                        click: (event) => {
+                        click: (event: Event) => {
                             this.selectItem(event, i);
                         },
                     },
@@ -116,18 +146,18 @@ class LinkTools extends BaseFloat {
         this.oldVNode = vnode;
     }
 
-    selectItem(event, item) {
+    selectItem(event: Event, item: LinkToolIcon) {
         event.preventDefault();
         event.stopPropagation();
-        const { contentState } = this.muya;
+        const { contentState } = this.muya as IMuyaWithContentState;
         switch (item.type) {
             case 'unlink':
-                contentState.unlink(this.linkInfo);
+                contentState?.unlink(this.linkInfo);
                 this.hide();
                 break;
 
             case 'jump':
-                this.options.jumpClick(this.linkInfo);
+                this.options.jumpClick?.(this.linkInfo);
                 this.hide();
                 break;
         }

--- a/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/hint.spec.ts
+++ b/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/hint.spec.ts
@@ -1,0 +1,51 @@
+// @vitest-environment happy-dom
+import { describe, expect, it } from 'vitest';
+import { CLASS_NAMES } from '../../../config';
+import { Muya } from '../../../muya';
+
+// P3 defensive lock for marktext `81af43be` ("hide quick-insert hint on
+// empty paragraph"). The hint is the `Type / to insert blocks` ghost text
+// that the CSS rule `.mu-show-quick-insert-hint .mu-paragraph.mu-active >
+// .mu-paragraph-content:first-of-type::after` paints into empty active
+// paragraphs.
+//
+// Toggle is muya option `hideQuickInsertHint` (default false). The wiring
+// lives in `muya.ts::getContainer` — when the option is true, the
+// `mu-show-quick-insert-hint` class is **not** added to the editor
+// container, so the CSS selector never matches and the ghost text never
+// renders. If a refactor ever drops that branch, every consumer that opted
+// out of the hint would suddenly see it again, silently.
+//
+// We only assert the class-on-container contract (the public observable),
+// not the CSS rule itself.
+
+const HINT_CLASS = CLASS_NAMES.MU_SHOW_QUICK_INSERT_HINT;
+
+function bootMuya(options: Partial<ConstructorParameters<typeof Muya>[1]> = {}) {
+    // happy-dom does not define MUYA_VERSION; Muya reads window.MUYA_VERSION
+    // at construct time. Provide a stub so the field-init doesn't throw.
+    (window as any).MUYA_VERSION ??= 'test';
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    // Constructor wires up the container; we never call init() so no blocks
+    // are registered and no editor lifecycle is started.
+    const muya = new Muya(host, options as any);
+    return muya;
+}
+
+describe('muya option hideQuickInsertHint — container class wiring', () => {
+    it('omitted (default): container has the mu-show-quick-insert-hint class', () => {
+        const muya = bootMuya();
+        expect(muya.domNode.classList.contains(HINT_CLASS)).toBe(true);
+    });
+
+    it('hideQuickInsertHint: false → container has the class (hint visible)', () => {
+        const muya = bootMuya({ hideQuickInsertHint: false });
+        expect(muya.domNode.classList.contains(HINT_CLASS)).toBe(true);
+    });
+
+    it('hideQuickInsertHint: true → container does NOT have the class (hint suppressed)', () => {
+        const muya = bootMuya({ hideQuickInsertHint: true });
+        expect(muya.domNode.classList.contains(HINT_CLASS)).toBe(false);
+    });
+});

--- a/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/hint.spec.ts
+++ b/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/hint.spec.ts
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { CLASS_NAMES } from '../../../config';
 import { Muya } from '../../../muya';
 
@@ -20,16 +20,43 @@ import { Muya } from '../../../muya';
 // not the CSS rule itself.
 
 const HINT_CLASS = CLASS_NAMES.MU_SHOW_QUICK_INSERT_HINT;
+const MUYA_VERSION_KEY = 'MUYA_VERSION';
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: unknown;
+let hadVersion = false;
+
+beforeEach(() => {
+    // happy-dom does not define MUYA_VERSION; Muya reads window.MUYA_VERSION
+    // at construct time. Save the current value so afterEach can restore it.
+    hadVersion = MUYA_VERSION_KEY in window;
+    originalVersion = (window as any)[MUYA_VERSION_KEY];
+    (window as any)[MUYA_VERSION_KEY] = 'test';
+});
+
+afterEach(() => {
+    // Remove each editor host node from document.body to avoid DOM growth
+    // across tests in the same worker.
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    // Restore the pre-test value of window.MUYA_VERSION (delete if it was
+    // unset before we ran).
+    if (hadVersion)
+        (window as any)[MUYA_VERSION_KEY] = originalVersion;
+    else
+        delete (window as any)[MUYA_VERSION_KEY];
+});
 
 function bootMuya(options: Partial<ConstructorParameters<typeof Muya>[1]> = {}) {
-    // happy-dom does not define MUYA_VERSION; Muya reads window.MUYA_VERSION
-    // at construct time. Provide a stub so the field-init doesn't throw.
-    (window as any).MUYA_VERSION ??= 'test';
     const host = document.createElement('div');
     document.body.appendChild(host);
     // Constructor wires up the container; we never call init() so no blocks
     // are registered and no editor lifecycle is started.
     const muya = new Muya(host, options as any);
+    // Track the post-`getContainer` node (host is replaced in place, so the
+    // new container shares the body parent).
+    bootedHosts.push(muya.domNode);
     return muya;
 }
 


### PR DESCRIPTION
## Summary

A P3 tidy PR: defensive locks on four already-implemented items + `linkTools` type cleanup + three application-layer skip decisions.

### PR-9 — defensive locks on 4 already-implemented P3 items (14 new tests)

| Hash | Change | Tests |
|---|---|---|
| `ab97336e` highlight menu | `<mark>` already wired in `inlineFormatToolbar/config.ts` (`type: 'mark'` + `⇧+Cmd+H` shortcut) | 9 — lock 7 core inline-format types (`strong/em/u/del/mark/inline_code/link`) each present with an icon and not duplicated |
| `ef9fe756` underline | `<u>` already wired (`type: 'u'`), covered by the same 7-type defensive suite as `ab97336e` | (same suite) |
| `81af43be` quick-insert hint toggle | `muya.ts::getContainer` already reads `options.hideQuickInsertHint` to gate the `mu-show-quick-insert-hint` class | 3 — lock default / `false` / `true` class application |
| `1ef0d016` linkTools unlink/jump | **removes `@ts-nocheck`** + adds types (`ILinkInfo` / `ILinkToolsOptions` / `IMuyaWithContentState` boundary cast) | 2 — lock `selectItem` dispatch: unlink → `muya.contentState.unlink` / jump → `options.jumpClick` |

Every suite was first verified to fail under a red-phase mutation (temporary source flip) before being restored to green, so the tests are confirmed to catch the regressions they claim to lock.

### PR-12 — 3 application-layer skip decisions (MIGRATION.md)

Added to / updated in the P3 table:
- `c0c8ea4b` open external / local md link → `skipped` (Electron `shell.openExternal` path; lives at the application layer, outside the SDK boundary)
- `afe68891` SM.MS upload-delete link → `skipped` (uploader-specific; the new repo does not bundle an uploader)
- `435dca74` Unsplash search → `skipped` (network dependency + API key + significant UI surface — too heavy for a pure-markdown library)

## Test plan

- [x] `pnpm --filter @muyajs/core test` — 251 passing (+14 over 237 baseline)
- [x] `pnpm lint:types` — clean (`linkTools` no longer `@ts-nocheck`)
- [x] `pnpm check-circular` — no circular dependencies
- [x] `pnpm lint` — 0 errors (the 19 pre-existing warnings are unrelated to this PR)
- [x] Each new test suite was confirmed to fail under a red-phase mutation of the source it locks (and then restored to green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)