### PR TITLE
feat: muya.getTOC() public API (PR-15)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -81,7 +81,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | 1c42555a | block | 粘贴多行进 heading | PR-4a | `fixed`（提取 `mergePasteIntoHeading` 纯函数，6 个测试） |
 | dec7502e | block | setext heading | PR-2a | `test-only`（marked v16 lheading + walkTokens `headingStyle` 已就位；3 个回归测试） |
 | f00da152 | block | 嵌套块插表 crash | PR-7b | `verified-not-applicable`：marktext 老 `createFigure` 缺 anchor 校验导致 math/code/html/table 内插表崩；新仓 `canTurnIntoMenu` 同一道门把 table 也挡在外，`/table` quick-insert 只对 `paragraph.content` 触发。**新增 6 个回归测试**复用 `canTurnIntoMenu` 门同时锁住 table 不可嵌入 |
-| 9cb2cbe8 | toc | TOC 更新（如做 TOC 参考） | PR-13 | `skipped`（TOC 不是 muya v0.x 范围；以后做 TOC feature 时再回头看 marktext 此 fix） |
+| 9cb2cbe8 | toc | TOC 更新（如做 TOC 参考） | PR-15 | `fixed`：新仓加 `muya.getTOC()` 公共 API，对齐 marktext `tocCtrl.js`（同步 9cb2cbe8 `\s` 正则修复，让 NBSP/tab 前后置都能正确剥离 atx `#` 标记）。`state/getTOC.ts` 委托实现，`utils/slug.ts` 导出 `generateGithubSlug`（与 marktext url.js 一致：ASCII `\w` only）。`packages/core/src/index.ts` 导出 `ITocItem` 类型。**新增 10 个回归测试**：空文档、单 atx、多层级、setext、raw inline 保留、`\s` 正则修复、CJK/emoji 退化、重复标题 slug 稳定但 githubSlug 同、跨调用 slug 稳定、跳过非 heading 顶层块 |
 
 ## P2 — 编辑 / 光标 / 选择 / IME
 
@@ -243,6 +243,7 @@ Spec runner 用 `renderToStaticHTML(..., { sanitize: false })` 跑——衡量�
 | PR-5a (P3 code block 行号) | 1 | 1 | 100%（fixed，10 个测试） |
 | PR-6a | — | done | spec 合规基础设施落地（CM 572/652 = 87.7%, GFM 580/672 = 86.3%，1324 spec 测试 + 8 normalizer 单测 + 18 个 renderToStaticHTML 单测） |
 | PR-6b | — | done | marktext 测试补齐落地（footnote 8 个新测试 + 1 个 parser fix；round-trip 15 个测试 + 11 fixture；list-indent +1 dfm 策略） |
-| PR-13 (residuals) | 5 | 5 | 100%（5 项 A 组遗留收尾：1 skipped `9cb2cbe8`(TOC) + 3 verified-not-applicable `b8e2cd82`/`5b1cd85d`/`0baf2e9e`+`7de33f11` + 1 skipped (已拆条) `0a3fda63`+`2754e393`+`4b362e52`；新增 18 个防御测试: 2 sup/sub HTML + 16 DOMPurify XSS；post-refactor 拆出 11 个子条目: 2 pending + 6 verified-not-applicable + 3 skipped 应用层/docs） |
+| PR-13 (residuals) | 5 | 4 | 80%（4 项 A 组遗留收尾：3 verified-not-applicable `b8e2cd82`/`5b1cd85d`/`0baf2e9e`+`7de33f11` + 1 skipped (已拆条) `0a3fda63`+`2754e393`+`4b362e52`；`9cb2cbe8` 原计入此 PR 为 skipped，已转入 PR-15 处理；新增 18 个防御测试: 2 sup/sub HTML + 16 DOMPurify XSS；post-refactor 拆出 11 个子条目: 2 pending + 6 verified-not-applicable + 3 skipped 应用层/docs） |
+| PR-15 (TOC) | 1 | 1 | 100%（1 fixed `9cb2cbe8`：新增 `muya.getTOC()` 公共 API + `generateGithubSlug` helper + `ITocItem` 类型导出；10 个回归测试） |
 
-最后更新：2026-05-20（PR-13 收尾：5 条 A 组遗留 + post-refactor 11 子条目；新增 21 防御测试）
+最后更新：2026-05-20（PR-15 收尾：新增 `muya.getTOC()` 公共 API + 10 个回归测试；`9cb2cbe8` 由 PR-13 `skipped` 转 PR-15 `fixed`）

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -149,7 +149,12 @@ muya.on('json-change', (_changes) => {
     // console.log(JSON.stringify(muya.getState(), null, 2))
     // console.log(muya.getMarkdown())
     // console.log(JSON.stringify(_changes, null, 2));
+    // eslint-disable-next-line no-console -- demo log for manual TOC verification (PR-15)
+    console.log('[muya] TOC:', muya.getTOC());
 });
+
+// eslint-disable-next-line no-console -- demo log for manual TOC verification (PR-15)
+console.log('[muya] TOC (initial):', muya.getTOC());
 
 muya.on('focus', () => {
     // eslint-disable-next-line no-console -- demo log for manual focus verification

--- a/packages/core/src/__tests__/getTOC.spec.ts
+++ b/packages/core/src/__tests__/getTOC.spec.ts
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { Muya } from '../muya';
+
+// Regression coverage for PR-15: re-introduces marktext's TOC API as a
+// public muya method (`muya.getTOC()`). Mirrors marktext's `tocCtrl.js`
+// behaviour and the 9cb2cbe8 regex fix (`/^\s*#{1,6}\s{1,}/` to handle
+// non-breaking spaces and tab-prefixed atx markers).
+//
+//  - Only top-level heading blocks are surfaced (matches marktext
+//    iterating `this.blocks`).
+//  - Heading text is the raw inner content — inline markdown markers are
+//    NOT stripped. marktext used `block.children[0].text` for the same
+//    reason.
+//  - Slug is a stable per-block identifier (so `getTOC()` returns the
+//    same slug across multiple invocations on the same document); duplicate
+//    headings keep distinct slugs but share `githubSlug`. The marktext
+//    fix didn't dedupe and we don't either — that is the caller's call.
+//  - `generateGithubSlug` mirrors marktext url.js literally: ASCII `\w`
+//    only, so CJK / emoji collapse to hyphens. Future Unicode-aware
+//    slugging is a separate change.
+
+const MUYA_VERSION_KEY = 'MUYA_VERSION';
+const bootedHosts: HTMLElement[] = [];
+let originalVersion: unknown;
+let hadVersion = false;
+
+beforeEach(() => {
+    hadVersion = MUYA_VERSION_KEY in window;
+    originalVersion = (window as any)[MUYA_VERSION_KEY];
+    (window as any)[MUYA_VERSION_KEY] = 'test';
+});
+
+afterEach(() => {
+    while (bootedHosts.length) {
+        const host = bootedHosts.pop()!;
+        host.remove();
+    }
+    if (hadVersion)
+        (window as any)[MUYA_VERSION_KEY] = originalVersion;
+    else
+        delete (window as any)[MUYA_VERSION_KEY];
+});
+
+function bootMuya(markdown: string): Muya {
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    const muya = new Muya(host, { markdown } as any);
+    muya.init();
+    bootedHosts.push(muya.domNode);
+    return muya;
+}
+
+describe('muya.getTOC()', () => {
+    it('returns [] for an empty document', () => {
+        const muya = bootMuya('');
+        expect(muya.getTOC()).toEqual([]);
+    });
+
+    it('extracts a single atx h1', () => {
+        const muya = bootMuya('# Hello world');
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(1);
+        expect(toc[0].lvl).toBe(1);
+        expect(toc[0].content).toBe('Hello world');
+        expect(typeof toc[0].slug).toBe('string');
+        expect(toc[0].slug.length).toBeGreaterThan(0);
+        expect(toc[0].githubSlug).toBe('hello-world');
+    });
+
+    it('extracts mixed h1 / h2 / h3 in document order with correct levels', () => {
+        const md = `# Alpha\n\n## Beta\n\n### Gamma\n\n# Delta`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc.map(item => [item.lvl, item.content])).toEqual([
+            [1, 'Alpha'],
+            [2, 'Beta'],
+            [3, 'Gamma'],
+            [1, 'Delta'],
+        ]);
+    });
+
+    it('extracts setext h1 (===) and h2 (---) without the underline', () => {
+        const md = `Title One\n=========\n\nTitle Two\n---------\n`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(2);
+        expect(toc[0]).toMatchObject({ lvl: 1, content: 'Title One' });
+        expect(toc[1]).toMatchObject({ lvl: 2, content: 'Title Two' });
+    });
+
+    it('keeps raw markdown inline markers in `content` (no inline parsing)', () => {
+        // marktext reads `block.children[0].text` — the raw source of the
+        // heading line — so `**bold**` and `[link](url)` are preserved as
+        // typed. Consumers that want rendered text should run their own
+        // inline tokenizer over `content`.
+        const md = `## **bold** and [link](https://example.com)`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(1);
+        expect(toc[0].content).toBe('**bold** and [link](https://example.com)');
+    });
+
+    it('strips the leading hash run robustly (9cb2cbe8 \\s regex fix)', () => {
+        // Pre-9cb2cbe8 marktext used `/^ *#{1,6} {1,}/` (plain ASCII
+        // space). After the fix it accepts any whitespace before the
+        // markers and between markers and text, so headings authored with
+        // tabs / NBSPs / other unicode whitespace strip cleanly.
+        // CommonMark only accepts ASCII space/tab around atx markers, but
+        // the fix still matters because the underlying `text` is the
+        // source line and we want defensive matching.
+        const md = `#\tTabbed heading`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(1);
+        expect(toc[0].lvl).toBe(1);
+        expect(toc[0].content).toBe('Tabbed heading');
+    });
+
+    it('githubSlug strips non-ASCII letters and emoji and collapses whitespace', () => {
+        // marktext url.js literal behavior: `[^\w\s-]/g` removes CJK and
+        // emoji because JS `\w` is ASCII-only without the `/u` flag.
+        // Future Unicode-aware slugging would be a separate change; this
+        // test locks the marktext-faithful output in place.
+        const md = `# 你好 World 🎉\n\n# API & Usage Examples!`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc[0].githubSlug).toBe('-world-');
+        expect(toc[1].githubSlug).toBe('api-usage-examples');
+    });
+
+    it('duplicate headings share githubSlug but get distinct stable slugs', () => {
+        const md = `## Foo\n\n## Foo`;
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(2);
+        expect(toc[0].githubSlug).toBe('foo');
+        expect(toc[1].githubSlug).toBe('foo');
+        expect(toc[0].slug).not.toBe(toc[1].slug);
+    });
+
+    it('returns the same `slug` across repeated getTOC() calls on the same document', () => {
+        const muya = bootMuya('# Stable');
+        const first = muya.getTOC()[0].slug;
+        const second = muya.getTOC()[0].slug;
+        expect(first).toBe(second);
+    });
+
+    it('skips non-heading top-level blocks (paragraph, code, list)', () => {
+        const md = [
+            'a paragraph',
+            '',
+            '```js',
+            'console.log(1)',
+            '```',
+            '',
+            '- list item',
+            '',
+            '## Only Heading',
+        ].join('\n');
+        const muya = bootMuya(md);
+        const toc = muya.getTOC();
+        expect(toc).toHaveLength(1);
+        expect(toc[0].content).toBe('Only Heading');
+        expect(toc[0].lvl).toBe(2);
+    });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export { en, ja, zh } from './locales';
 
 export { Muya } from './muya';
+export type { ITocItem } from './state/getTOC';
 export { MarkdownToHtml } from './state/markdownToHtml';
 export { renderToStaticHTML } from './state/renderToStaticHTML';
 export type { IRenderToStaticHTMLOptions } from './state/renderToStaticHTML';

--- a/packages/core/src/muya.ts
+++ b/packages/core/src/muya.ts
@@ -1,5 +1,6 @@
 import type { Listener } from './event/types';
 import type { ILocale } from './i18n/types';
+import type { ITocItem } from './state/getTOC';
 import type { TState } from './state/types';
 import type { IMuyaOptions } from './types';
 import {
@@ -10,6 +11,7 @@ import { Editor } from './editor/index';
 
 import EventCenter from './event/index';
 import I18n from './i18n/index';
+import { getTOC } from './state/getTOC';
 import { Ui } from './ui/ui';
 import './assets/styles/blockSyntax.css';
 import './assets/styles/index.css';
@@ -106,6 +108,20 @@ export class Muya {
 
     getMarkdown() {
         return this.editor.jsonState.getMarkdown();
+    }
+
+    /**
+     * Return a flat table of contents for the current document.
+     *
+     * Mirrors marktext's `tocCtrl.getTOC` (including the 9cb2cbe8 regex
+     * fix). Only top-level atx / setext headings are surfaced; nested
+     * headings inside blockquotes / list items are ignored, same as
+     * marktext. `content` is the raw heading text (inline markdown not
+     * parsed); `slug` is a stable per-block identifier; `githubSlug` is
+     * the GitHub-style anchor derived from `content`.
+     */
+    getTOC(): ITocItem[] {
+        return getTOC(this);
     }
 
     undo() {

--- a/packages/core/src/state/getTOC.ts
+++ b/packages/core/src/state/getTOC.ts
@@ -39,10 +39,14 @@ export function getTOC(muya: Muya): ITocItem[] {
 
     const items: ITocItem[] = [];
 
-    scrollPage.children.forEach((node) => {
+    // Walk the linked list directly instead of `forEach`, which materialises
+    // every top-level block into an array via `[...iterator()]` (see
+    // `LinkedList.forEach`). For large documents the intermediate array is
+    // pure waste.
+    for (const node of scrollPage.children.iterator()) {
         const { blockName } = node;
         if (blockName !== 'atx-heading' && blockName !== 'setext-heading')
-            return;
+            continue;
 
         const block = node as IHeadingBlock;
         const head = block.children.head as Content | null;
@@ -61,7 +65,7 @@ export function getTOC(muya: Muya): ITocItem[] {
             slug: stableSlug(block),
             githubSlug: generateGithubSlug(content),
         });
-    });
+    }
 
     return items;
 }

--- a/packages/core/src/state/getTOC.ts
+++ b/packages/core/src/state/getTOC.ts
@@ -1,0 +1,67 @@
+import type Content from '../block/base/content';
+import type Parent from '../block/base/parent';
+import type { Muya } from '../muya';
+import { getUniqueId } from '../utils';
+import { generateGithubSlug } from '../utils/slug';
+
+export interface ITocItem {
+    content: string;
+    lvl: number;
+    slug: string;
+    githubSlug: string;
+}
+
+interface IHeadingBlock extends Parent {
+    meta: { level: number };
+}
+
+// Stable per-block slug. marktext exposed `block.key` for the same purpose
+// (a DOM-id-friendly anchor that survives across `getTOC()` calls). The new
+// block tree has no `.key`, so we lazily assign one and cache by block
+// instance — same heading → same slug, even across repeated invocations.
+// Different muya instances build different blocks, so there is no risk of
+// cross-instance collision.
+const slugCache = new WeakMap<Parent, string>();
+
+function stableSlug(block: Parent): string {
+    let slug = slugCache.get(block);
+    if (slug == null) {
+        slug = getUniqueId();
+        slugCache.set(block, slug);
+    }
+    return slug;
+}
+
+export function getTOC(muya: Muya): ITocItem[] {
+    const { scrollPage } = muya.editor;
+    if (!scrollPage)
+        return [];
+
+    const items: ITocItem[] = [];
+
+    scrollPage.children.forEach((node) => {
+        const { blockName } = node;
+        if (blockName !== 'atx-heading' && blockName !== 'setext-heading')
+            return;
+
+        const block = node as IHeadingBlock;
+        const head = block.children.head as Content | null;
+        const text = head?.text ?? '';
+
+        // 9cb2cbe8: `\s` instead of literal ASCII space so unicode
+        // whitespace / tabs before or between the `#` markers also strip
+        // cleanly.
+        const content = blockName === 'setext-heading'
+            ? text.trim()
+            : text.replace(/^\s*#{1,6}\s+/, '').trim();
+
+        items.push({
+            content,
+            lvl: block.meta.level,
+            slug: stableSlug(block),
+            githubSlug: generateGithubSlug(content),
+        });
+    });
+
+    return items;
+}

--- a/packages/core/src/utils/slug.ts
+++ b/packages/core/src/utils/slug.ts
@@ -1,0 +1,12 @@
+// Mirrors marktext's `generateGithubSlug` from `src/muya/lib/utils/url.js`
+// (referenced verbatim by PR-15). The regex uses ASCII `\w`, so CJK and
+// emoji collapse to hyphens — same as marktext. A Unicode-aware variant
+// would be a separate, opt-in change.
+export function generateGithubSlug(text: string): string {
+    return text
+        .trim()
+        .toLowerCase()
+        .replace(/[^\w\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-');
+}


### PR DESCRIPTION
## Summary

Restores marktext `9cb2cbe8`'s table-of-contents capability by exposing it as a public `muya.getTOC(): ITocItem[]` API. PR-13 originally tagged this commit as `skipped` ("TOC is out of muya v0.x scope"); this PR reverses that call — TOC is a standard markdown SDK affordance and unblocks external `@muyajs/core` consumers.

**API + tests only — no UI** (UI belongs in the application layer; marktext made the same split).

## API

```ts
muya.getTOC(): ITocItem[]

interface ITocItem {
  content: string;     // raw heading text (after stripping `#`; inline markdown not parsed)
  lvl: number;         // 1-6 heading level
  slug: string;        // stable per-block internal key (for DOM #id jumps)
  githubSlug: string;  // GitHub-style anchor (for URL jumps)
}
```

`ITocItem` is publicly re-exported from `packages/core/src/index.ts`.

## Implementation notes

- `packages/core/src/state/getTOC.ts` — walks `scrollPage.children` via the LinkedList iterator (no intermediate array allocation), picks up `atx-heading` / `setext-heading`, and reads the raw text from `block.children.head.text`.
- `packages/core/src/utils/slug.ts` — `generateGithubSlug` mirrors marktext `src/muya/lib/utils/url.js` literally (ASCII `\w` only; CJK / emoji collapse to hyphens). A Unicode-aware variant would be a separate, opt-in change.
- Syncs the **marktext `9cb2cbe8` regex fix** `/^\s*#{1,6}\s+/` (replacing `/^ *#{1,6} {1,}/`) so NBSP / tab before or between `#` markers also strip cleanly.
- `slug` is cached in a module-level `WeakMap<Parent, string>`: marktext used `block.key`, the new block tree has no `.key`, and a WeakMap is the minimum-touch equivalent — the same block returns the same slug across repeated `getTOC()` calls. Different muya instances build different block instances, so there is no cross-instance collision risk.
- **No dedupe** on `githubSlug` (marktext doesn't dedupe either; the caller decides).

## Test coverage (10)

1. Empty document → `[]`
2. Single atx h1 → complete `lvl` / `content` / `githubSlug` / `slug`
3. Mixed h1 / h2 / h3 → document order + per-item level
4. setext h1 (`===`) / h2 (`---`) → level from `meta.level`, underline not in `content`
5. Inline markdown in headings (`**bold**`, `[link](url)`) → preserved verbatim (mirrors marktext `block.children[0].text`)
6. `9cb2cbe8` `\s` regex fix → `#\tTitle` strips cleanly
7. CJK / emoji → `githubSlug` collapses to `-world-` / `api-usage-examples` (matches marktext)
8. Duplicate headings → distinct `slug`, identical `githubSlug`
9. Repeated `getTOC()` calls return a stable `slug` (WeakMap cache)
10. Non-heading top-level blocks (paragraph / code / list) are skipped

`pnpm --filter @muyajs/core test`: **35 files / 318 tests** (baseline 34/308 + 10); `pnpm lint:types` clean; `pnpm check-circular` no cycles.

## MIGRATION.md

- `9cb2cbe8` row moved from `PR-13 skipped` to `PR-15 fixed` (with full migration note).
- PR-13 progress: `5 / 5` → `5 / 4` (9cb2cbe8 moved out).
- New PR-15 progress row: `1 / 1 100%`.
- "Last updated" timestamp refreshed.

## Decisions

- **No UI**: application-layer concern (marktext kept this split too).
- **No `githubSlug` dedupe**: matches marktext; more predictable for SDK consumers.
- **`slug` via WeakMap, not added to the block class**: avoids touching the `block/` surface; the semantic ("same block → same id") is fully covered by a WeakMap cache.
- **CJK / emoji degradation**: marktext degrades them too (no `/u` flag on `\w`). Aligning literally first; a Unicode-aware opt-in can ship later.

## Inline review fixes

- `LinkedList.forEach` materialises the whole list into an intermediate array via `[...iterator()]`. Switched to a `for ... of` over `scrollPage.children.iterator()` so large documents don't pay that allocation per call (commit `39f39ff`).

## References

- marktext `src/muya/lib/contentState/tocCtrl.js`
- marktext `9cb2cbe8` (regex fix)
- marktext `src/muya/lib/utils/url.js` `generateGithubSlug`

## Test plan

- [x] `pnpm --filter @muyajs/core test` (35/318)
- [x] `pnpm lint:types` clean
- [x] `pnpm check-circular` no cycles
- [x] `pnpm dev` manual smoke: `examples/src/main.ts` logs `muya.getTOC()` on init and on every `json-change`; verify in browser console that heading edits change the array and paragraph edits don't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)