### PR TITLE
fix: reference link/image markdown loading + roundtrip (PR-16)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -82,6 +82,7 @@ PR 分组对应方案第三节的 5 个系列 + 后续 PR-6 测试合规：
 | dec7502e | block | setext heading | PR-2a | `test-only`（marked v16 lheading + walkTokens `headingStyle` 已就位；3 个回归测试） |
 | f00da152 | block | 嵌套块插表 crash | PR-7b | `verified-not-applicable`：marktext 老 `createFigure` 缺 anchor 校验导致 math/code/html/table 内插表崩；新仓 `canTurnIntoMenu` 同一道门把 table 也挡在外，`/table` quick-insert 只对 `paragraph.content` 触发。**新增 6 个回归测试**复用 `canTurnIntoMenu` 门同时锁住 table 不可嵌入 |
 | 9cb2cbe8 | toc | TOC 更新（如做 TOC 参考） | PR-15 | `fixed`：新仓加 `muya.getTOC()` 公共 API，对齐 marktext `tocCtrl.js`（同步 9cb2cbe8 `\s` 正则修复，让 NBSP/tab 前后置都能正确剥离 atx `#` 标记）。`state/getTOC.ts` 委托实现，`utils/slug.ts` 导出 `generateGithubSlug`（与 marktext url.js 一致：ASCII `\w` only）。`packages/core/src/index.ts` 导出 `ITocItem` 类型。**新增 10 个回归测试**：空文档、单 atx、多层级、setext、raw inline 保留、`\s` 正则修复、CJK/emoji 退化、重复标题 slug 稳定但 githubSlug 同、跨调用 slug 稳定、跳过非 heading 顶层块 |
+| reference link/image | parser+state | markdown 加载时 reference definition 丢失（marked v16 `def` block token 未处理）+ reference image 不走 `loadImageAsync` 解析后 src + 内联 label 查找漏大小写 | PR-16 | `fixed`：`markdownToState.ts` 新增 `case 'def'`，把 marked v16 提取的 `[label]: url "title"` block token 还原为 paragraph state（沿用 marktext "definition 是 paragraph text" 模型，**不**引入新 state 节点）；`loadImageAsync.ts` 缓存并返回 resolved `url`（marktext `domsrc` 等价），`referenceImage.ts` 用它作为 `<img src>` fallback；`lexer.ts` 两处 `labels.has(...)` 调用前 `.toLowerCase()`（CommonMark §6.5）；`ILinkReferenceDefinitionState` 标 `@deprecated`（unused，v0.3 移除）。**新增 8 个回归测试**：def→paragraph 保留、round-trip、inline tokenize、Full/Collapsed/Shortcut 三形式、title 透传、case-insensitive lookup、duplicate label 取首条、orphan ref-link |
 
 ## P2 — 编辑 / 光标 / 选择 / IME
 
@@ -245,5 +246,6 @@ Spec runner 用 `renderToStaticHTML(..., { sanitize: false })` 跑——衡量�
 | PR-6b | — | done | marktext 测试补齐落地（footnote 8 个新测试 + 1 个 parser fix；round-trip 15 个测试 + 11 fixture；list-indent +1 dfm 策略） |
 | PR-13 (residuals) | 5 | 4 | 80%（4 项 A 组遗留收尾：3 verified-not-applicable `b8e2cd82`/`5b1cd85d`/`0baf2e9e`+`7de33f11` + 1 skipped (已拆条) `0a3fda63`+`2754e393`+`4b362e52`；`9cb2cbe8` 原计入此 PR 为 skipped，已转入 PR-15 处理；新增 18 个防御测试: 2 sup/sub HTML + 16 DOMPurify XSS；post-refactor 拆出 11 个子条目: 2 pending + 6 verified-not-applicable + 3 skipped 应用层/docs） |
 | PR-15 (TOC) | 1 | 1 | 100%（1 fixed `9cb2cbe8`：新增 `muya.getTOC()` 公共 API + `generateGithubSlug` helper + `ITocItem` 类型导出；10 个回归测试） |
+| PR-16 (reference link/image) | 1 | 1 | 100%（fixed：`markdownToState` 加 `case 'def'` + `loadImageAsync` 返回 resolved `url` + `referenceImage` 用它 + `lexer.ts` label lookup 大小写规范化 + `ILinkReferenceDefinitionState` 标 `@deprecated`；8 个回归测试 + examples demo） |
 
-最后更新：2026-05-20（PR-15 收尾：新增 `muya.getTOC()` 公共 API + 10 个回归测试；`9cb2cbe8` 由 PR-13 `skipped` 转 PR-15 `fixed`）
+最后更新：2026-05-21（PR-16 落地：reference link/image markdown 加载 + round-trip 修复，8 个回归测试，全套 342 测试通过）

--- a/examples/src/data.ts
+++ b/examples/src/data.ts
@@ -456,4 +456,9 @@ A short paragraph with a footnote reference[^note] and another[^pandoc].
     - bullet item one
     - bullet item two
 
-![](https://jingan2.guankou.net/haopic/jj20/389023/010323033238341796.jpg)IMAGE`;
+![](https://jingan2.guankou.net/haopic/jj20/389023/010323033238341796.jpg)IMAGE
+
+This is a [reference link][example] and a ![ref image][img].
+
+[example]: https://example.com "Example Title"
+[img]: https://placekitten.com/200/200 "Kitten"`;

--- a/packages/core/src/inlineRenderer/lexer.ts
+++ b/packages/core/src/inlineRenderer/lexer.ts
@@ -363,7 +363,10 @@ function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: I
         const rLinkTo = inlineRules.reference_link.exec(src);
         if (
             rLinkTo
-            && labels.has(rLinkTo[3] || rLinkTo[1])
+            // CommonMark §6.5: link labels match case-insensitively. The
+            // labels Map is populated by `collectReferenceDefinitions` with
+            // lowercased keys, so normalize the candidate before lookup.
+            && labels.has((rLinkTo[3] || rLinkTo[1]).toLowerCase())
             && isLengthEven(rLinkTo[2])
             && isLengthEven(rLinkTo[4])
             && lowerPriority(src, rLinkTo[0].length, validateRules)
@@ -403,7 +406,7 @@ function tokenizerFac(src: string, beginRules: BeginRules | null, inlineRules: I
         const rImageTo = inlineRules.reference_image.exec(src);
         if (
             rImageTo
-            && labels.has(rImageTo[3] || rImageTo[1])
+            && labels.has((rImageTo[3] || rImageTo[1]).toLowerCase())
             && isLengthEven(rImageTo[2])
             && isLengthEven(rImageTo[4])
         ) {

--- a/packages/core/src/inlineRenderer/renderer/index.ts
+++ b/packages/core/src/inlineRenderer/renderer/index.ts
@@ -93,6 +93,7 @@ class Renderer {
         {
             id: string;
             isSuccess: boolean;
+            url?: string;
             width?: number;
             height?: number;
         }

--- a/packages/core/src/inlineRenderer/renderer/loadImageAsync.ts
+++ b/packages/core/src/inlineRenderer/renderer/loadImageAsync.ts
@@ -17,6 +17,7 @@ export default function loadImageAsync(
     const { src, isUnknownType } = imageInfo;
     let id: string;
     let isSuccess: boolean | undefined;
+    let url: string | undefined;
     let w;
     let h;
 
@@ -77,6 +78,7 @@ export default function loadImageAsync(
                 this.loadImageMap.set(src, {
                     id,
                     isSuccess: true,
+                    url,
                     width,
                     height,
                 });
@@ -103,9 +105,14 @@ export default function loadImageAsync(
     else {
         id = cached.id;
         isSuccess = cached.isSuccess;
+        url = cached.url;
         w = cached.width;
         h = cached.height;
     }
 
-    return { id, isSuccess, width: w, height: h };
+    // marktext's loadImageAsync returns `domsrc` (the resolved URL — for
+    // remote sources it's just the src, for local files it carries a cache-
+    // busting query). Reference images need this so the rendered <img> uses
+    // the resolved URL rather than the raw label-derived href.
+    return { id, isSuccess, url, width: w, height: h };
 }

--- a/packages/core/src/inlineRenderer/renderer/referenceImage.ts
+++ b/packages/core/src/inlineRenderer/renderer/referenceImage.ts
@@ -39,7 +39,16 @@ export default function referenceImage(
             CLASS_NAMES.MU_COPY_REMOVE,
         ));
     }
-    selector = id ? `span#${id}.${imageClass}` : `span.${imageClass}`;
+    // Mirror `image.ts` (inline image): `loadImageMap` keys by `src`, so two
+    // reference images sharing the same `href` share the same cached `id`.
+    // Once the load has resolved (`isSuccess === true`), suffix the DOM id
+    // with the token's start offset so each occurrence gets a unique element
+    // id. While the load is in flight we keep the raw id so the
+    // `document.querySelector('#'+id)` lookup in `loadImageAsync.then()` can
+    // still find the first instance to mount the resolved <img> into.
+    selector = id
+        ? `span#${isSuccess ? `${id}_${token.range.start}` : id}.${imageClass}`
+        : `span.${imageClass}`;
     selector += `.${CLASS_NAMES.MU_OUTPUT_REMOVE}`;
     if (isSuccess)
         selector += `.${className}`;

--- a/packages/core/src/inlineRenderer/renderer/referenceImage.ts
+++ b/packages/core/src/inlineRenderer/renderer/referenceImage.ts
@@ -29,9 +29,10 @@ export default function referenceImage(
     const { src } = imageSrc;
     let id;
     let isSuccess;
+    let resolvedSrc: string | undefined;
     let selector;
     if (src) {
-        ({ id, isSuccess } = this.loadImageAsync(
+        ({ id, isSuccess, url: resolvedSrc } = this.loadImageAsync(
             imageSrc,
             { alt },
             className,
@@ -48,7 +49,10 @@ export default function referenceImage(
     return isSuccess
         ? [
                 h(selector, tag),
-                h(`img.${CLASS_NAMES.MU_COPY_REMOVE}`, { props: { alt, src, title } }),
+                // Prefer the resolved URL from the loadImageAsync cache (marktext's
+                // `domsrc` parity); fall back to the raw src if the cache hasn't
+                // been populated for some reason.
+                h(`img.${CLASS_NAMES.MU_COPY_REMOVE}`, { props: { alt, src: resolvedSrc ?? src, title } }),
             ]
         : [h(selector, tag)];
 }

--- a/packages/core/src/state/__tests__/referenceLink.spec.ts
+++ b/packages/core/src/state/__tests__/referenceLink.spec.ts
@@ -1,0 +1,145 @@
+import type { TContainerState, TState } from '../types';
+import { describe, expect, it } from 'vitest';
+import { tokenizer } from '../../inlineRenderer/lexer';
+import { beginRules } from '../../inlineRenderer/rules';
+import { MarkdownToState } from '../markdownToState';
+import ExportMarkdown from '../stateToMarkdown';
+
+// Mirrors `InlineRenderer.collectReferenceDefinitions` so the spec can verify
+// the full markdown → state → label-collection → inline tokenize pipeline
+// without spinning up a real Muya instance.
+function collectLabels(states: TState[]) {
+    const labels = new Map<string, { href: string; title: string }>();
+
+    const visit = (sts: TState[]) => {
+        for (const st of sts) {
+            if (st.name === 'paragraph') {
+                const tokens = beginRules.reference_definition.exec(st.text);
+                if (tokens) {
+                    const label = (tokens[2] + tokens[3]).toLowerCase();
+                    if (!labels.has(label)) {
+                        labels.set(label, {
+                            href: tokens[6],
+                            title: tokens[10] || '',
+                        });
+                    }
+                }
+            }
+            else if ((st as TContainerState).children) {
+                visit((st as TContainerState).children);
+            }
+        }
+    };
+
+    visit(states);
+    return labels;
+}
+
+function parse(md: string) {
+    const states = new MarkdownToState({
+        footnote: false,
+        math: false,
+        isGitlabCompatibilityEnabled: false,
+        trimUnnecessaryCodeBlockEmptyLines: false,
+        frontMatter: false,
+    }).generate(md);
+    const labels = collectLabels(states);
+    return { states, labels };
+}
+
+function tokenize(text: string, labels: Map<string, { href: string; title: string }>) {
+    return tokenizer(text, {
+        labels,
+        hasBeginRules: false,
+        options: { superSubScript: true, footnote: false },
+    });
+}
+
+describe('reference link / image — markdown ↔ state round-trip', () => {
+    it('case 1 — loading markdown with [label]: url keeps the definition as a paragraph state', () => {
+        const md = `foo [bar][1]\n\n[1]: https://example.com "title"\n`;
+        const { states } = parse(md);
+
+        const paragraphs = states.filter(s => s.name === 'paragraph') as Array<{ name: 'paragraph'; text: string }>;
+        const defParagraph = paragraphs.find(p => /^\s*\[1\]:/.test(p.text));
+        expect(defParagraph, 'reference definition should be preserved as a paragraph').toBeDefined();
+        expect(defParagraph!.text).toContain('[1]: https://example.com');
+        expect(defParagraph!.text).toContain('"title"');
+    });
+
+    it('case 2 — round-trip: getMarkdown output contains the reference definition line', () => {
+        const md = `foo [bar][1]\n\n[1]: https://example.com "title"\n`;
+        const { states } = parse(md);
+        const out = new ExportMarkdown().generate(states);
+        expect(out).toMatch(/\[1\]:\s*https:\/\/example\.com/);
+        expect(out).toContain('"title"');
+    });
+
+    it('case 3 — inline tokenize: reference_link resolves to a token whose label maps to href', () => {
+        const md = `foo [bar][1]\n\n[1]: https://example.com\n`;
+        const { states, labels } = parse(md);
+
+        expect(labels.get('1')?.href).toBe('https://example.com');
+
+        const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph' && s.text!.startsWith('foo')) as { text: string };
+        const tokens = tokenize(para.text, labels);
+        const refTok = tokens.find(t => t.type === 'reference_link') as any;
+        expect(refTok, 'reference_link token should be emitted once labels are known').toBeDefined();
+        expect(refTok.label).toBe('1');
+    });
+
+    it('case 4 — inline tokenize: Full / Collapsed / Shortcut forms all produce reference_link tokens', () => {
+        const md = `A [full][1] and [collapsed][] and [shortcut] here.\n\n[1]: https://a.example\n[collapsed]: https://b.example\n[shortcut]: https://c.example\n`;
+        const { states, labels } = parse(md);
+
+        const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph' && s.text!.startsWith('A ')) as { text: string };
+        const tokens = tokenize(para.text, labels);
+        const refToks = tokens.filter(t => t.type === 'reference_link') as any[];
+        expect(refToks.length).toBe(3);
+        expect(refToks[0].isFullLink).toBe(true);
+        expect(refToks[1].isFullLink).toBe(false);
+        expect(refToks[2].isFullLink).toBe(false);
+    });
+
+    it('case 5 — definition with title: title propagates through label lookup', () => {
+        const md = `foo [bar][ref]\n\n[ref]: https://example.com "Ref Title"\n`;
+        const { labels } = parse(md);
+
+        const info = labels.get('ref');
+        expect(info?.href).toBe('https://example.com');
+        expect(info?.title).toBe('Ref Title');
+    });
+
+    it('case 6 — label matching is case-insensitive', () => {
+        const md = `foo [bar][REF]\n\n[ref]: https://example.com\n`;
+        const { states, labels } = parse(md);
+
+        expect(labels.get('ref')?.href).toBe('https://example.com');
+
+        const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph' && s.text!.startsWith('foo')) as { text: string };
+        const tokens = tokenize(para.text, labels);
+        const refTok = tokens.find(t => t.type === 'reference_link') as any;
+        expect(refTok, 'reference_link must match label irrespective of case').toBeDefined();
+    });
+
+    it('case 7 — duplicate label: first definition wins', () => {
+        const md = `foo [bar][dup]\n\n[dup]: https://first.example\n[dup]: https://second.example\n`;
+        const { labels } = parse(md);
+
+        expect(labels.get('dup')?.href).toBe('https://first.example');
+    });
+
+    it('case 8 — orphan reference_link with no matching definition stays as plain text', () => {
+        const md = `Look at [missing][nope] please.\n`;
+        const { states, labels } = parse(md);
+
+        expect(labels.size).toBe(0);
+
+        const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph') as { text: string };
+        const tokens = tokenize(para.text, labels);
+        const refTok = tokens.find(t => t.type === 'reference_link');
+        expect(refTok, 'no reference_link token should fire without a matching definition').toBeUndefined();
+        const raw = tokens.map((t: any) => t.raw).join('');
+        expect(raw).toContain('[missing][nope]');
+    });
+});

--- a/packages/core/src/state/markdownToState.ts
+++ b/packages/core/src/state/markdownToState.ts
@@ -313,6 +313,23 @@ export class MarkdownToState {
                     break;
                 }
 
+                case 'def': {
+                    // Marked v16 hoists `[label]: url "title"` reference
+                    // definitions to block-level `def` tokens. Lower them back
+                    // to paragraph state nodes so the rest of the pipeline —
+                    // `InlineRenderer.collectReferenceDefinitions` (regex scan
+                    // over paragraph text) and round-trip serialization —
+                    // keeps working without a dedicated state node.
+                    // Aligns with marktext's "definition is paragraph text"
+                    // model. See plan section 13 (PR-16).
+                    state = {
+                        name: 'paragraph' as const,
+                        text: (token as any).raw.replace(/\n+$/, ''),
+                    };
+                    parentList[0].push(state);
+                    break;
+                }
+
                 case 'footnote': {
                     // The footnote extension (utils/marked/extensions/footnote.ts)
                     // emits a parent token whose `tokens` array holds nested

--- a/packages/core/src/state/types.ts
+++ b/packages/core/src/state/types.ts
@@ -39,6 +39,14 @@ export interface IHtmlBlockState {
     text: string;
 }
 
+/**
+ * @deprecated Reference definitions are stored as paragraph state nodes whose
+ * `text` is the raw `[label]: url "title"` line (matches marktext's
+ * "definition is paragraph text" model). `InlineRenderer.collectReferenceDefinitions`
+ * regex-scans paragraphs to build the labels Map. This interface is unused
+ * across the codebase and exists only for legacy type compatibility; remove
+ * in v0.3.
+ */
 export interface ILinkReferenceDefinitionState {
     name: 'link-reference-definition';
     text: string;


### PR DESCRIPTION
## Summary

Fix `[label]: url "title"` reference definitions silently disappearing when markdown is loaded into the editor, and the reference-image renderer using the raw label-derived href instead of the resolved URL. The bug surfaced only on the **markdown → state load path** (`muya.setMarkdown(...)` / `options.markdown`), not on live editing where the user types the definition directly.

**Approach (plan §13 方案 A — single PR, minimal-invasive):** keep marktext's "definition is paragraph text" model. Lower marked v16's hoisted `def` block tokens back into paragraph state instead of introducing a new `ILinkReferenceDefinitionState` block class.

### Root-cause chain (before fix)

1. marked v16 extracts `[1]: url` as a `def` block token.
2. `markdownToState.ts` switch has **no `case 'def'`** → falls through to `default → debug.warn → discard`.
3. `InlineRenderer.collectReferenceDefinitions` regex-scans paragraphs for the definition; finds nothing → `labels` Map is empty.
4. Inline lexer's `labels.has(...)` returns false → no `reference_link` token emitted.
5. `<a>` never renders; `getMarkdown()` round-trip drops `[1]: url` permanently.

### Changes

- **`state/markdownToState.ts`** — add `case 'def'` that lowers the token back to a paragraph state (`text = token.raw.trimEnd()`).
- **`inlineRenderer/lexer.ts`** — lowercase the label candidate before `labels.has(...)` in the `reference_link` and `reference_image` branches (CommonMark §6.5 case-insensitive; `collectReferenceDefinitions` already stores lowercased keys, so the lookup side just needed normalizing).
- **`inlineRenderer/renderer/loadImageAsync.ts`** + **`renderer/index.ts`** — cache and return the resolved `url` (marktext `domsrc` parity).
- **`inlineRenderer/renderer/referenceImage.ts`** — `<img src>` uses `resolvedSrc ?? src`.
- **`state/types.ts`** — `ILinkReferenceDefinitionState` marked `@deprecated` (unused; remove in v0.3).
- **`examples/src/data.ts`** — append reference link/image demo block.
- **`MIGRATION.md`** — PR-16 row added to P1 table + progress stats.

### Tests: 334 → 342 (+8)

New `packages/core/src/state/__tests__/referenceLink.spec.ts` covers:

1. Loading markdown with `[1]: url` preserves the definition as a paragraph state.
2. `getMarkdown()` round-trip outputs the definition line.
3. Inline tokenize: `reference_link` resolves with an href once labels are populated.
4. Full / Collapsed / Shortcut forms all emit `reference_link` tokens.
5. Definition with title — title propagates through label lookup.
6. Case-insensitive label matching (`[REF]` ↔ `[ref]: url`).
7. Duplicate label — first definition wins (CommonMark).
8. Orphan reference link with no matching definition stays as plain text.

**Red→green log:** initial run: 7 failed / 1 passed (case 8 already green via the orphan path). After `case 'def'`: 1 failed (case 6 case-insensitive). After lexer `.toLowerCase()`: 8/8 green.

### Verification

- `pnpm --filter @muyajs/core test` — 39 files / **342 passed**.
- `pnpm --filter @muyajs/core lint:types` — clean.
- `pnpm check-circular` — clean.
- `pnpm --filter @muyajs/core test:spec:commonmark` — **652/652** (no unexpected passes / fails).
- `pnpm --filter @muyajs/core test:spec:gfm` — **672/672**.

Spec pass rates are unchanged on purpose — `renderToStaticHTML` (which the spec runner uses) goes through marked's built-in HTML renderer, not `markdownToState`. The bug only affected the editor's state path, which the new unit tests now cover.

### Notes on scope decisions

- **No new state node**: did not implement `ILinkReferenceDefinitionState` — sticking with marktext's text-only model keeps `collectReferenceDefinitions` untouched and avoids a Block-class register churn. The deprecated type stays as an export for one release cycle.
- **Inline `image.ts` left alone**: `loadImage` returns `url === src` in muya's web context (no cache-busting), so the structural symmetry with `referenceImage` already holds at the data level; modifying the renderer would risk regressions on the `urlMap` / `loading-alt` override branches.

## Test plan

- [x] `pnpm test` — 342 / 342
- [x] `pnpm lint:types` — clean
- [x] `pnpm check-circular` — clean
- [x] `pnpm test:spec:commonmark` — 652 / 652
- [x] `pnpm test:spec:gfm` — 672 / 672
- [ ] `pnpm dev` manual smoke: the demo block in `examples/src/data.ts` (reference link is clickable `<a href>`, reference image renders, `getMarkdown()` round-trip preserves the definition lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)