### PR TITLE
docs: examples + README + CLAUDE.md updates for v0.2.0 (B-final)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,38 @@
 # Changelog
 
+# [0.2.0] (2026-05-21)
+
+The marktext-muya backport batch. 22 PRs (#208–#230) brought the upstream marktext muya tree onto `@muyajs/core` end-to-end, with full test coverage on every change.
+
+### Features
+
+* footnote complete — block class + UI tool + click wiring + HTML backref ([#221](https://github.com/marktext/muya/pull/221))
+* reference link/image — markdown loading + round-trip + image domsrc ([#229](https://github.com/marktext/muya/pull/229))
+* `LinkTools` dispatch for `<a>`, reference link, markdown link ([#226](https://github.com/marktext/muya/pull/226))
+* `muya.getTOC()` public API ([#228](https://github.com/marktext/muya/pull/228))
+* `focus` / `blur` events + format cursor jump-to-end after applying bold/italic/etc. ([#225](https://github.com/marktext/muya/pull/225))
+* code block line numbers (`codeBlockLineNumbers` editor option) ([#219](https://github.com/marktext/muya/pull/219))
+* image small-image class + inline resize-bar suppression ([#224](https://github.com/marktext/muya/pull/224))
+* CommonMark 0.31 + GFM 0.29-gfm spec conformance infrastructure ([#218](https://github.com/marktext/muya/pull/218))
+* backport marktext muya parser test suites ([#220](https://github.com/marktext/muya/pull/220))
+
+### Bug Fixes
+
+* P0 crashes — `normalizeTable` row count, `loadImageAsync` failed cache ([#208](https://github.com/marktext/muya/pull/208))
+* XSS protections — `langInputContent`, hyperlinks, Mermaid, code block ([#209](https://github.com/marktext/muya/pull/209))
+* parser CommonMark/GFM correctness + regression baseline ([#212](https://github.com/marktext/muya/pull/212))
+* `stateToMarkdown` serialization baseline ([#213](https://github.com/marktext/muya/pull/213))
+* defensive inline regressions for bold+code, parens-in-dest ([#214](https://github.com/marktext/muya/pull/214))
+* backport marktext muya editor/cursor/IME/autopair/table fixes ([#211](https://github.com/marktext/muya/pull/211))
+* clipboard / paste / copy correctness ([#210](https://github.com/marktext/muya/pull/210), [#215](https://github.com/marktext/muya/pull/215), [#216](https://github.com/marktext/muya/pull/216), [#217](https://github.com/marktext/muya/pull/217))
+* `EventCenter` listener leak + once-listener iteration mutation ([#230](https://github.com/marktext/muya/pull/230))
+
+### Internal
+
+* test coverage 1 → 386 tests (43 files)
+* conformance baseline locked at CommonMark 87.7% / GFM 86.3%; regression-gated by `expected-failures.json`
+* residuals cleanup — XSS assessment + post-refactor split + skipped tags ([#223](https://github.com/marktext/muya/pull/223), [#227](https://github.com/marktext/muya/pull/227))
+
 # [0.1.0](https://github.com/marktext/muya/compare/v0.0.39...v0.1.0) (2026-05-20)
 
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,7 @@ Run from repo root (Turbo fans out to packages):
 - `pnpm dev` — start the examples Vite dev server (`turbo dev:demo`, persistent task).
 - `pnpm build` — `tsc && vite build` in `packages/core`, emits `lib/{es,umd,cjs}` and `lib/types`.
 - `pnpm test` / `pnpm coverage` — Vitest (`--passWithNoTests`). For a single test in core: `pnpm --filter @muyajs/core exec vitest run path/to/file.test.ts` or `pnpm --filter @muyajs/core test:watch`.
+- `pnpm --filter @muyajs/core test:spec` — run the CommonMark 0.31 + GFM 0.29-gfm fixture suites against `renderToStaticHTML(..., { sanitize: false })`. `test:spec:commonmark` / `test:spec:gfm` scope to one suite. Pass/fail counts are locked by `packages/core/test/spec/expected-failures.json`: any listed example that starts passing fails the suite (remove it from the list), and any unlisted example that starts failing fails the suite. Net effect: compliance can only go up. Baseline lives in `packages/core/test/spec/conformance.md` (CommonMark 87.7% / GFM 86.3% at PR-6a).
 - `pnpm lint` / `pnpm lint:fix` — ESLint over `packages` (antfu config, see below for project-specific rules).
 - `pnpm lint:types` — `tsc --noEmit` per package via Turbo.
 - `pnpm lint:css` — Stylelint over all CSS.
@@ -52,6 +53,8 @@ Concrete blocks live under `src/block/{commonMark,gfm,extra,content}` and **must
 - `JSONState` (`state/index.ts`) is the source-of-truth document. It exposes `ot-json1` `invert`/`compose`/`transform` statics — the architecture is set up for OT-based collaborative editing even if no transport is wired in.
 - `markdownToState.ts` parses Markdown (via `marked`) into the state tree; `stateToMarkdown.ts` serializes back; `markdownToHtml.ts` and `htmlToMarkdown.ts` (using `turndown` + `joplin-turndown-plugin-gfm`) bridge HTML. `MarkdownToHtml` is re-exported from the public API.
 - Inline text edits are encoded as `ot-text-unicode` ops nested inside the json1 ops (see the `d.es` branch in `Editor.updateContents`).
+- **Reference link/image definitions** (`[ref]: url "title"`) are NOT a first-class block type in state. `markdownToState`'s `case 'def'` re-emits the raw definition line back into a `paragraph` state node so it round-trips losslessly through the markdown serializer. `InlineRenderer.collectReferenceDefinitions()` runs over the live block tree on every render pass to populate a labels Map that the lexer consults when expanding `[text][ref]` and `![alt][ref]`. `ILinkReferenceDefinitionState` exists as a deprecated stub for compatibility — do not introduce new code paths that produce it.
+- **TOC** is derived on-demand via `getTOC(muya)` (`state/getTOC.ts`); the public method is `muya.getTOC()` (`packages/core/src/muya.ts`). Slugs follow the marktext-compatible regex carried over in commit `9cb2cbe8`.
 
 ### Inline rendering and DOM
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,13 @@
 
 ## Features
 
-- **CommonMark + GFM** blocks: paragraphs, ATX/Setext headings, bullet/ordered/task lists, code fences, tables, block quotes, horizontal rules, raw HTML, images.
+- **CommonMark + GFM** blocks: paragraphs, ATX/Setext headings, bullet/ordered/task lists, code fences, tables, block quotes, horizontal rules, raw HTML, images. Parser baseline tracked against CommonMark 0.31 and GFM 0.29-gfm (see `packages/core/test/spec/conformance.md`).
 - **Inline formats** with a floating toolbar, plus optional super/subscript, footnotes, front matter, and inline math.
+- **Footnotes** end-to-end: `[^id]` references and `[^id]: …` definitions render with an interactive footnote tool and backref anchors on export.
+- **Reference links and images**: `[text][ref]` / `![alt][ref]` resolve from `[ref]: url "title"` definitions on both render and round-trip.
+- **Code block line numbers** — opt in with `codeBlockLineNumbers: true` to render gutters alongside fenced/indented code (and previewable blocks).
 - **Diagrams & rich content**: [KaTeX](https://katex.org/) math, [Mermaid](https://mermaid.js.org/), [Vega/Vega-Lite](https://vega.github.io/), [PlantUML](https://plantuml.com/), and [Prism](https://prismjs.com/) syntax highlighting in code blocks.
-- **Markdown ↔ HTML** round-trip via [`marked`](https://github.com/markedjs/marked) (read path) and [`turndown`](https://github.com/mixmark-io/turndown) + `joplin-turndown-plugin-gfm` (write path). `MarkdownToHtml` is exposed as a standalone utility.
+- **Markdown ↔ HTML** round-trip via [`marked`](https://github.com/markedjs/marked) (read path) and [`turndown`](https://github.com/mixmark-io/turndown) + `joplin-turndown-plugin-gfm` (write path). `MarkdownToHtml` is exposed as a standalone utility; output passes through [DOMPurify](https://github.com/cure53/DOMPurify) (`sanitizeHyperlink` + `isValidAttribute`) for XSS-safe rendering.
 - **Search and replace** with regex support, plus undo/redo history.
 - **i18n** out of the box: English, Chinese, and Japanese locales ship with the package.
 - **JSON state model** built on [`ot-json1`](https://github.com/ottypes/json1) / [`ot-text-unicode`](https://github.com/ottypes/text-unicode) — wire it up to your own transport for collaborative editing.
@@ -31,10 +34,12 @@ Muya is a browser library and expects a bundler (Vite, webpack, Rollup, esbuild,
 import {
     CodeBlockLanguageSelector,
     EmojiSelector,
+    FootnoteTool,
     ImageEditTool,
     ImageResizeBar,
     ImageToolBar,
     InlineFormatToolbar,
+    LinkTools,
     Muya,
     ParagraphFrontButton,
     ParagraphFrontMenu,
@@ -50,6 +55,7 @@ import '@muyajs/core/lib/style.css';
 
 // 1. Register the UI plugins you need (once, globally on the class).
 Muya.use(EmojiSelector);
+Muya.use(FootnoteTool);
 Muya.use(InlineFormatToolbar);
 Muya.use(ImageToolBar);
 Muya.use(ImageResizeBar);
@@ -58,6 +64,13 @@ Muya.use(ImageEditTool, {
     imageAction: async () => 'https://example.com/uploaded.png',
 });
 Muya.use(CodeBlockLanguageSelector);
+Muya.use(LinkTools, {
+    jumpClick: (linkInfo) => {
+        const href = linkInfo?.href;
+        if (href && /^https?:\/\//.test(href))
+            window.open(href, '_blank', 'noopener,noreferrer');
+    },
+});
 Muya.use(ParagraphFrontButton);
 Muya.use(ParagraphFrontMenu);
 Muya.use(ParagraphQuickInsertMenu);
@@ -70,6 +83,8 @@ Muya.use(PreviewToolBar);
 const container = document.querySelector('#editor') as HTMLElement;
 const muya = new Muya(container, {
     markdown: '# Hello, Muya',
+    footnote: true,
+    codeBlockLineNumbers: true,
 });
 
 // 3. Optional: switch the UI language before init.
@@ -97,8 +112,16 @@ The `Muya` instance returned from `new Muya(el, options)` exposes:
 | `find('previous' \| 'next')` | Move the active match. |
 | `replace(value, { isSingle, isRegexp })` | Replace the active match or all matches. |
 | `selectAll()` | Select the entire document. |
+| `getTOC()` | Snapshot the current heading outline as `Array<{ level, text, slug }>`. |
 | `on(event, fn)` / `off(event, fn)` / `once(event, fn)` | Subscribe to editor events. |
 | `destroy()` | Tear down the editor and free DOM listeners. |
+
+Standalone utilities exported from the package root:
+
+| Export | Purpose |
+| --- | --- |
+| `MarkdownToHtml` | Server-safe Markdown → HTML class (`new MarkdownToHtml(md).generate()`). |
+| `renderToStaticHTML(stateOrMarkdown, opts?)` | One-shot static HTML renderer; pass `{ sanitize: false }` only for trusted input (parser conformance tests use this). |
 
 Useful events emitted on the editor:
 
@@ -106,6 +129,7 @@ Useful events emitted on the editor:
 | --- | --- |
 | `json-change` | OT operations describing the latest document mutation. The full state can be read back via `muya.getState()` or serialized to Markdown via `muya.getMarkdown()`. |
 | `selection-change` | New selection (`{ anchor, focus, path }`). |
+| `focus` / `blur` | Fired when the contenteditable surface gains or loses focus. |
 
 The full set of constructor options (font size, list defaults, math/footnote toggles, front matter delimiters, Mermaid/Vega themes, etc.) is described by `IMuyaOptions` in [`packages/core/src/types.ts`](./packages/core/src/types.ts); defaults live in `MUYA_DEFAULT_OPTIONS` in [`packages/core/src/config/index.ts`](./packages/core/src/config/index.ts).
 
@@ -119,6 +143,8 @@ Plugins are floating tools/menus that you opt into with `Muya.use(Plugin, option
 | `EmojiSelector` | `:` trigger emoji picker. |
 | `CodeBlockLanguageSelector` | Language picker inside fenced code blocks. |
 | `ImageToolBar`, `ImageResizeBar`, `ImageEditTool` | Image-related affordances; `ImageEditTool` accepts `imagePathPicker` and `imageAction` callbacks for upload flows. |
+| `LinkTools` | Hover toolbar over native `<a>`, markdown links, and reference links. Takes a `jumpClick` callback to control jump-out behavior. |
+| `FootnoteTool` | Floating popover for editing footnote definitions; requires the `footnote: true` editor option. |
 | `ParagraphFrontButton`, `ParagraphFrontMenu` | The handle and menu that appear to the left of the active block. |
 | `ParagraphQuickInsertMenu` | The `/` slash-command menu for inserting blocks. |
 | `TableColumnToolbar`, `TableDragBar`, `TableRowColumMenu` | Table editing affordances. |
@@ -228,6 +254,17 @@ awk -v v="$VERSION" '$0 ~ "^# \\["v"\\]"{flag=1; next} /^## \[/{flag=0} flag' \
     CHANGELOG.md > /tmp/release-notes.md
 gh release create "v$VERSION" --title "v$VERSION" --notes-file /tmp/release-notes.md
 ```
+
+## Recent updates
+
+**v0.2.0 (in flight)** — the marktext-muya backport batch. 22 PRs (#208–#230) ported the upstream marktext muya tree onto `@muyajs/core` end-to-end:
+
+- New surface: footnote block + tool, reference links/images, `LinkTools`, `getTOC()` public API, `focus` / `blur` events, code block line numbers, image small-image + inline resize-bar suppression.
+- Parser conformance: CommonMark 0.31 and GFM 0.29-gfm fixture runners (`pnpm --filter @muyajs/core test:spec`) with a locked baseline (87.7% / 86.3%) and a regression gate via `expected-failures.json`.
+- Hardening: XSS protections (hyperlink + Mermaid + code-block + langInput input via DOMPurify), normalizeTable crash fix, loadImageAsync failure cache, `stateToMarkdown` serialization baseline, clipboard/paste/copy corrections, editor cursor / IME / autopair / table navigation fixes, EventCenter listener-leak + once-iteration fix.
+- Tests: 1 → 386 unit tests (43 files).
+
+See [`CHANGELOG.md`](./CHANGELOG.md) for the full per-PR list and [`MIGRATION.md`](./MIGRATION.md) for the rolling migration log.
 
 ## Roadmap
 

--- a/examples/src/data.ts
+++ b/examples/src/data.ts
@@ -261,6 +261,21 @@ title: muya
 author: jocs
 ---
 
+# Heading levels
+
+# H1 ATX heading
+## H2 ATX heading
+### H3 ATX heading
+#### H4 ATX heading
+##### H5 ATX heading
+###### H6 ATX heading
+
+Setext H1
+=========
+
+Setext H2
+---------
+
 # Inline Format
 
 **strong** *emphasis* \`inline code\` &gt; <u>underline</u> <mark>highlight</mark> <ruby>北京<rt>Beijing</rt></ruby> [Baidu](http://www.baidu.com) H0~2~ X^5^
@@ -272,6 +287,8 @@ Markdown link: [Anthropic](https://www.anthropic.com).
 Reference link: [Wikipedia][wiki] (definition below).
 
 HTML anchor: <a href="https://github.com/marktext/muya">marktext/muya on GitHub</a>.
+
+Autolink: <https://commonmark.org>.
 
 [wiki]: https://en.wikipedia.org "Wikipedia"
 
@@ -292,6 +309,27 @@ line end
 
 \`\`\`
 const b = "foo"
+\`\`\`
+
+\`\`\`typescript
+// Long fenced code block to showcase PR-5a line numbers
+// (enable via Muya option codeBlockLineNumbers: true).
+import { Muya } from '@muyajs/core';
+
+const container = document.querySelector('#editor')!;
+const muya = new Muya(container, {
+    markdown: '# hello',
+    codeBlockLineNumbers: true,
+});
+
+muya.init();
+
+muya.on('json-change', () => {
+    console.log('changed');
+});
+
+muya.on('focus', () => console.log('focus'));
+muya.on('blur', () => console.log('blur'));
 \`\`\`
 
 \`\`\`math
@@ -455,6 +493,10 @@ foo bar
 
 > foo
 > bar
+>
+> > nested quote level 2
+> >
+> > > nested quote level 3
 
 A short paragraph with a footnote reference[^note] and another[^pandoc].
 

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -88,6 +88,7 @@ const selectAllBtn: HTMLButtonElement = document.querySelector('#select-all')!;
 const muya = new Muya(container, {
     markdown: DEFAULT_MARKDOWN,
     footnote: true,
+    codeBlockLineNumbers: true,
 });
 
 muya.locale(zh);


### PR DESCRIPTION
## Summary

Closes out the marktext-muya migration (PRs #208–#230) by syncing the docs/demo surface. **No source changes** — baseline 43 files / 386 tests unchanged.

### examples/
- `data.ts`: extended default markdown with H1–H6 ATX + Setext H1/H2, an autolink, a long fenced TypeScript block (showcases PR-5a line numbers), and a 3-level nested blockquote. Existing demos for inline format, links, math, mermaid/vega-lite/plantuml, table, lists, task list, footnote, reference link/image kept.
- `main.ts`: enabled `codeBlockLineNumbers: true` so PR-5a is visible.

### README.md
- Features list calls out footnotes, reference links/images, code-block line numbers, CommonMark 0.31 + GFM 0.29-gfm conformance baseline, DOMPurify XSS protections.
- API table adds `getTOC()`; new "Standalone utilities" table covers `MarkdownToHtml` and `renderToStaticHTML`; events table adds `focus` / `blur`.
- Bundled UI plugins table adds `FootnoteTool` and `LinkTools`.
- New "Recent updates" section summarises v0.2.0 highlights.
- Quick start snippet syncs to register `FootnoteTool` + `LinkTools` and pass `footnote: true` + `codeBlockLineNumbers: true`.

### CLAUDE.md
- State-and-round-trip section: documents reference-definition handling (`markdownToState` `case 'def'` re-emits as paragraph, `InlineRenderer.collectReferenceDefinitions()` populates labels Map, `ILinkReferenceDefinitionState` is a deprecated stub) and the `getTOC()` derivation.
- Commands section: documents `test:spec`, `test:spec:commonmark`, `test:spec:gfm`, the `expected-failures.json` regression gate, and the conformance baseline (`packages/core/test/spec/conformance.md`).

### CHANGELOG.md
- Pre-writes a `[0.2.0]` highlight section above `[0.1.0]` so the merge with `release-it`'s auto-generated output is trivial when `pnpm release 0.2.0` runs.

## Test plan

- [x] `pnpm --filter @muyajs/core test` — 43 files / 386 tests pass
- [x] `pnpm lint:types` — clean
- [x] `pnpm check-circular` — no circular deps
- [x] `pnpm lint` — 0 errors / 20 pre-existing warnings (none new)
- [ ] Reviewer: `pnpm dev` and confirm: H1–H6 render; long TS code block shows line numbers; footnotes are clickable; reference link/image render as `<a>`/`<img>`; console logs `[muya] TOC (initial): …` on load and `[muya] TOC: …` on changes; `[muya] focus` / `[muya] blur` log on focus changes.

## Follow-up

After merge, run `pnpm release 0.2.0` (needs Node ≥20.19/≥22.13/≥24 and interactive npm 2FA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)