### PR TITLE
refactor: remove all explicit any + enable ts/no-explicit-any lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -6,6 +6,12 @@ function typescriptPreset() {
     return {
         files: ['**/*.ts', '**/*.tsx'],
         rules: {
+            // Ban `any` (annotations, casts, generics). Genuine escape
+            // hatches (the block-constructor registry's `state: any`, the
+            // event Listener's `(...args: any[])`) are explicit
+            // `eslint-disable-next-line ts/no-explicit-any` comments at
+            // the source so they remain visible and reviewable.
+            'ts/no-explicit-any': 'error',
             'ts/naming-convention': [
                 'warn',
                 // Interfaces' names should start with a capital 'I'.

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -28,9 +28,10 @@ import { DEFAULT_MARKDOWN } from './data';
 import './style.css';
 
 // Fix Intl.Segmenter is not work on firefox.
-if (!(Intl as any).Segmenter) {
+const intlNs = Intl as unknown as { Segmenter?: typeof Intl.Segmenter };
+if (!intlNs.Segmenter) {
     const polyfill = await import('intl-segmenter-polyfill/dist/bundled');
-    (Intl as any).Segmenter = await polyfill.createIntlSegmenterPolyfill();
+    intlNs.Segmenter = await polyfill.createIntlSegmenterPolyfill() as typeof Intl.Segmenter;
 }
 
 async function imagePathPicker() {
@@ -96,7 +97,7 @@ muya.locale(zh);
 muya.init();
 
 // Expose for in-browser debugging during PR-8 manual testing.
-(window as any).muya = muya;
+window.muya = muya;
 
 // Language switcher
 const languageSelect: HTMLSelectElement = document.querySelector('#language-select')!;

--- a/examples/src/vite-env.d.ts
+++ b/examples/src/vite-env.d.ts
@@ -1,1 +1,30 @@
 /// <reference types="vite/client" />
+
+import type { Muya } from '@muyajs/core';
+
+declare global {
+    interface Window {
+        // Debugging handle assigned by main.ts so the editor instance is
+        // reachable from the browser devtools console.
+        muya?: Muya;
+    }
+
+    // `Intl.Segmenter` (Stage 4, ES2022) is not in the ES2020 TS lib the
+    // examples package targets. main.ts polyfills it on Firefox where the
+    // runtime engine lacks support — both the feature-detect (`Intl.Segmenter`)
+    // and the polyfill assignment need a real declaration.
+    namespace Intl {
+        interface ISegmenterOptions {
+            granularity?: 'grapheme' | 'word' | 'sentence';
+        }
+        interface ISegmentData {
+            segment: string;
+            index: number;
+            input: string;
+        }
+        class Segmenter {
+            constructor(locales?: string | string[], options?: ISegmenterOptions);
+            segment(input: string): Iterable<ISegmentData>;
+        }
+    }
+}

--- a/packages/core/src/__tests__/getTOC.spec.ts
+++ b/packages/core/src/__tests__/getTOC.spec.ts
@@ -21,15 +21,14 @@ import { Muya } from '../muya';
 //    only, so CJK / emoji collapse to hyphens. Future Unicode-aware
 //    slugging is a separate change.
 
-const MUYA_VERSION_KEY = 'MUYA_VERSION';
 const bootedHosts: HTMLElement[] = [];
-let originalVersion: unknown;
+let originalVersion: string | undefined;
 let hadVersion = false;
 
 beforeEach(() => {
-    hadVersion = MUYA_VERSION_KEY in window;
-    originalVersion = (window as any)[MUYA_VERSION_KEY];
-    (window as any)[MUYA_VERSION_KEY] = 'test';
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
 });
 
 afterEach(() => {
@@ -38,15 +37,15 @@ afterEach(() => {
         host.remove();
     }
     if (hadVersion)
-        (window as any)[MUYA_VERSION_KEY] = originalVersion;
+        window.MUYA_VERSION = originalVersion as string;
     else
-        delete (window as any)[MUYA_VERSION_KEY];
+        delete (window as Partial<Window>).MUYA_VERSION;
 });
 
 function bootMuya(markdown: string): Muya {
     const host = document.createElement('div');
     document.body.appendChild(host);
-    const muya = new Muya(host, { markdown } as any);
+    const muya = new Muya(host, { markdown } as ConstructorParameters<typeof Muya>[1]);
     muya.init();
     bootedHosts.push(muya.domNode);
     return muya;

--- a/packages/core/src/block/base/__tests__/autoPair.spec.ts
+++ b/packages/core/src/block/base/__tests__/autoPair.spec.ts
@@ -51,12 +51,16 @@ function invokeAutoPair(
     cursorOffset: number,
     flags: { isInInlineMath?: boolean; isInInlineCode?: boolean; type?: string } = {},
 ) {
+    // `Content.prototype.autoPair` is a real instance method but the
+    // structural fakeThis doesn't satisfy the full Content surface. The
+    // cursor params are `{ offset }`-shaped; the production type accepts
+    // `INodeOffset | null` so the structural object lines up if cast to it.
     return Content.prototype.autoPair.call(
-        fakeThis as any,
+        fakeThis as unknown as Content,
         event,
         newText,
-        { offset: cursorOffset } as any,
-        { offset: cursorOffset } as any,
+        { offset: cursorOffset },
+        { offset: cursorOffset },
         flags.isInInlineMath ?? false,
         flags.isInInlineCode ?? false,
         flags.type ?? 'format',

--- a/packages/core/src/block/base/__tests__/formatCursor.spec.ts
+++ b/packages/core/src/block/base/__tests__/formatCursor.spec.ts
@@ -24,12 +24,22 @@ interface IOffset {
     offset: number;
 }
 
+// `_addFormat` is declared private on Format, so accessing it via the
+// prototype requires bypassing visibility — this structural type captures
+// the signature the helper here actually invokes.
+interface FormatProtoAddFormat {
+    _addFormat: (
+        this: { text: string },
+        type: string,
+        cursor: { start: IOffset; end: IOffset },
+    ) => void;
+}
+
 function applyAddFormat(text: string, start: number, end: number, type: string) {
     const fakeThis = { text } as { text: string };
     const startOffset: IOffset = { offset: start };
     const endOffset: IOffset = { offset: end };
-    // _addFormat is private; call via the prototype with a fake `this`.
-    (Format.prototype as any)._addFormat.call(fakeThis, type, {
+    (Format.prototype as unknown as FormatProtoAddFormat)._addFormat.call(fakeThis, type, {
         start: startOffset,
         end: endOffset,
     });

--- a/packages/core/src/block/base/__tests__/formatUnlink.spec.ts
+++ b/packages/core/src/block/base/__tests__/formatUnlink.spec.ts
@@ -12,15 +12,26 @@ import Format from '../format';
 // `this.muya.eventCenter.emit`, so a structurally-typed fake `this` is
 // enough — no Muya bootstrap needed (same pattern as `formatCursor.spec`).
 
+interface IFakeFormatThis {
+    text: string;
+    setCursor: ReturnType<typeof vi.fn>;
+    muya: { eventCenter: { emit: ReturnType<typeof vi.fn> } };
+}
+
+// `Format.prototype.unlink` is a real instance method (declared on the class)
+// but isn't picked up by the public Format type when accessed via prototype.
+// Cast to a record of methods to call it with a structural fake.
+interface FormatProtoUnlink { unlink: (this: IFakeFormatThis, info: { range: { start: number; end: number } | null; text: string }) => void }
+
 function applyUnlink(text: string, range: { start: number; end: number }, anchorText: string) {
     const emit = vi.fn();
     const setCursor = vi.fn();
-    const fakeThis = {
+    const fakeThis: IFakeFormatThis = {
         text,
         setCursor,
         muya: { eventCenter: { emit } },
-    } as any;
-    (Format.prototype as any).unlink.call(fakeThis, { range, text: anchorText });
+    };
+    (Format.prototype as unknown as FormatProtoUnlink).unlink.call(fakeThis, { range, text: anchorText });
     return { text: fakeThis.text as string, emit, setCursor };
 }
 
@@ -70,12 +81,12 @@ describe('format.unlink — replaces link source with visible anchor', () => {
         const src = 'untouched';
         const emit = vi.fn();
         const setCursor = vi.fn();
-        const fakeThis = {
+        const fakeThis: IFakeFormatThis = {
             text: src,
             setCursor,
             muya: { eventCenter: { emit } },
-        } as any;
-        (Format.prototype as any).unlink.call(fakeThis, { range: null, text: 'whatever' });
+        };
+        (Format.prototype as unknown as FormatProtoUnlink).unlink.call(fakeThis, { range: null, text: 'whatever' });
         expect(fakeThis.text).toBe(src);
         expect(setCursor).not.toHaveBeenCalled();
         expect(emit).not.toHaveBeenCalled();

--- a/packages/core/src/block/base/format.ts
+++ b/packages/core/src/block/base/format.ts
@@ -5,13 +5,12 @@ import type {
     Token,
 } from '../../inlineRenderer/types';
 import type { ICursor } from '../../selection/types';
-import type { IBulletListState, IOrderListState } from '../../state/types';
+import type { IBulletListState, IListItemState, IOrderListState } from '../../state/types';
 import type { Nullable } from '../../types';
 import type { IImageInfo } from '../../utils/image';
 import type AtxHeading from '../commonMark/atxHeading';
 import type BulletList from '../commonMark/bulletList';
 import type SetextHeading from '../commonMark/setextHeading';
-import type Parent from './parent';
 import Content from '../../block/base/content';
 import { ScrollPage } from '../../block/scrollPage';
 import {
@@ -902,8 +901,14 @@ class Format extends Content {
                                 text: matches[2],
                             };
                         }
+                        else if (node.isParent()) {
+                            return node.getState();
+                        }
                         else {
-                            return (node as any).getState();
+                            // Content leaves under a list item don't carry a
+                            // full state, but in practice every nested item
+                            // is a Parent at runtime (paragraph / inner-list).
+                            return { name: 'paragraph', text: '' };
                         }
                     }),
                 },
@@ -941,8 +946,9 @@ class Format extends Content {
                 };
                 const offset = list.offset(listItem);
                 list.forEachAt(offset + 1, undefined, (node) => {
-                    bulletListState.children.push((node as any).getState());
-                    (node as Parent).remove();
+                    if (node.isParent())
+                        bulletListState.children.push(node.getState() as IListItemState);
+                    node.remove();
                 });
 
                 const bulletList = ScrollPage.loadBlock(bulletListState.name).create(

--- a/packages/core/src/block/content/codeBlockContent/index.ts
+++ b/packages/core/src/block/content/codeBlockContent/index.ts
@@ -47,7 +47,7 @@ function parseSelector(str = '') {
             && (!str[tagName.length] || /#|\./.test(str[tagName.length]))
         ) {
             tag = tagName;
-            if (VOID_HTML_TAGS.includes(tagName as any))
+            if ((VOID_HTML_TAGS as readonly string[]).includes(tagName))
                 isVoid = true;
 
             str = str.substring(tagName.length);

--- a/packages/core/src/block/content/langInputContent/__tests__/escape.spec.ts
+++ b/packages/core/src/block/content/langInputContent/__tests__/escape.spec.ts
@@ -31,7 +31,7 @@ describe('escapeLangInputInnerHtml — code-block language identifier XSS', () =
         // highlights uses character offsets relative to the lang text
         const out = escapeLangInputInnerHtml('<bad>', [
             { start: 0, end: 5, active: false },
-        ] as any);
+        ]);
 
         // Highlight span must be a real element (class survives), bad tag must not.
         expect(out).toContain('class="mu-selection"');

--- a/packages/core/src/block/content/paragraphContent/index.ts
+++ b/packages/core/src/block/content/paragraphContent/index.ts
@@ -3,7 +3,12 @@ import type { ImageToken, LinkToken, Token } from '../../../inlineRenderer/types
 import type { ICursor } from '../../../selection/types';
 import type {
     IBlockQuoteState,
+    IBulletListState,
+    IListItemState,
+    IOrderListState,
     ITaskListItemState,
+    ITaskListState,
+    TState,
 } from '../../../state/types';
 import type { Nullable } from '../../../types';
 import type Content from '../../base/content';
@@ -18,6 +23,12 @@ import { isKeyboardEvent, isLengthEven } from '../../../utils';
 import logger from '../../../utils/logger';
 import Format from '../../base/format';
 import { ScrollPage } from '../../scrollPage';
+
+// `_unindentListItem` / `_indentListItem` walk parents typed as the loose
+// `Parent` super-class; at runtime the relevant nodes are always one of
+// these three list kinds, which carry a `meta` field with the bullet/order
+// shape. Narrow once instead of casting per access.
+type TListBlock = BulletList | OrderList | TaskList;
 
 enum UnindentType {
     INDENT,
@@ -189,18 +200,24 @@ class ParagraphContent extends Format {
             && isLengthEven(tableMatch[2])
         ) {
             const tableHeader = parseTableHeader(this.text);
-            const tableBlock = ScrollPage.loadBlock('table').createWithHeader(
-                this.muya,
-                tableHeader,
-            );
+            // Table extends the base `create` shape with a static
+            // `createWithHeader(muya, header)` factory; the registry-level
+            // IConstructor doesn't surface it.
+            const tableCtor = ScrollPage.loadBlock('table') as unknown as {
+                createWithHeader: (muya: Muya, header: string[]) => Parent;
+            };
+            const tableBlock = tableCtor.createWithHeader(this.muya, tableHeader);
 
             this.parent!.replaceWith(tableBlock);
 
-            // Set cursor at the first cell of second row.
-            tableBlock.firstChild
-                .find(1)
-                .firstContentInDescendant()
-                .setCursor(0, 0, true);
+            // Set cursor at the first cell of second row. The runtime chain
+            // is: table → table-body (Parent.firstChild) → row (find(1)) →
+            // first cell content (firstContentInDescendant). Asserted as
+            // Parent at each container hop since createWithHeader guarantees
+            // a populated structure.
+            const tableBody = tableBlock.firstChild as Parent;
+            const secondRow = tableBody.find(1) as Parent;
+            secondRow.firstContentInDescendant()?.setCursor(0, 0, true);
         }
         else if (tagName && VOID_HTML_TAGS.every(tag => tag !== tagName)) {
             const state = {
@@ -254,7 +271,12 @@ class ParagraphContent extends Format {
                 };
                 const offset = blockQuote!.offset(parent!);
                 blockQuote!.forEachAt(offset + 1, undefined, (node) => {
-                    newBlockState.children.push((node as any).getState());
+                    // forEachAt's callback gets `TreeNode` but the runtime
+                    // children of a blockquote are always Parent-derived
+                    // blocks (paragraph, list, …). isParent() narrows so
+                    // `getState()` (defined on Parent, not TreeNode) resolves.
+                    if (node.isParent())
+                        newBlockState.children.push(node.getState());
                     node.remove();
                 });
                 const newBlockQuote = ScrollPage.loadBlock(newBlockState.name).create(
@@ -308,14 +330,15 @@ class ParagraphContent extends Format {
 
                     default: {
                         const newParagraph = parent!.clone() as Paragraph;
-                        const newListState = {
+                        const newListState: IBulletListState | IOrderListState | ITaskListState = {
                             name: list.blockName,
                             meta: { ...list.meta },
-                            children: [] as any,
-                        };
+                            children: [],
+                        } as IBulletListState | IOrderListState | ITaskListState;
                         const offset = list.offset(listItem);
                         list.forEachAt(offset + 1, undefined, (node) => {
-                            newListState.children.push((node as any).getState());
+                            if (node.isParent())
+                                (newListState.children as TState[]).push(node.getState());
                             node.remove();
                         });
                         const newList = ScrollPage.loadBlock(newListState.name).create(
@@ -331,20 +354,21 @@ class ParagraphContent extends Format {
                 }
             }
             else {
-                const newListItemState = {
+                const newListItemState: IListItemState | ITaskListItemState = {
                     name: listItem.blockName,
-                    children: [] as any,
-                };
+                    children: [],
+                } as IListItemState | ITaskListItemState;
 
                 if (listItem.blockName === 'task-list-item') {
-                    (newListItemState as unknown as ITaskListItemState).meta = {
+                    (newListItemState as ITaskListItemState).meta = {
                         checked: false,
                     };
                 }
 
                 const offset = listItem.offset(parent!);
                 listItem.forEachAt(offset, undefined, (node) => {
-                    newListItemState.children.push((node as any).getState());
+                    if (node.isParent())
+                        newListItemState.children.push(node.getState());
                     node.remove();
                 });
 
@@ -588,13 +612,18 @@ class ParagraphContent extends Format {
             const newListItem = listItem.clone() as Parent;
             listParent.parent!.insertAfter(newListItem, listParent);
 
+            // At runtime, when unindentListItem runs, the surrounding `list`
+            // is always one of the three list block kinds — narrow once
+            // so `meta` resolves without `as any`.
+            const listAsList = list as TListBlock;
+
             if (
                 (listItem.next || list.next)
                 && newListItem.lastChild!.blockName !== list.blockName
             ) {
                 const state = {
                     name: list.blockName,
-                    meta: { ...(list as any).meta },
+                    meta: { ...listAsList.meta },
                     children: [],
                 };
                 const childList = ScrollPage.loadBlock(state.name).create(
@@ -608,10 +637,12 @@ class ParagraphContent extends Format {
                 const offset = list.offset(listItem);
 
                 list.forEachAt(offset + 1, undefined, (node) => {
-                    (newListItem.lastChild as Parent).append(
-                        (node as any).clone(),
-                        'user',
-                    );
+                    if (node.isParent()) {
+                        (newListItem.lastChild as Parent).append(
+                            node.clone() as Parent,
+                            'user',
+                        );
+                    }
                     node.remove();
                 });
             }
@@ -619,10 +650,12 @@ class ParagraphContent extends Format {
             if (list.next) {
                 const offset = listParent.offset(list);
                 listParent.forEachAt(offset + 1, undefined, (node) => {
-                    (newListItem.lastChild as Parent).append(
-                        (node as any).clone(),
-                        'user',
-                    );
+                    if (node.isParent()) {
+                        (newListItem.lastChild as Parent).append(
+                            node.clone() as Parent,
+                            'user',
+                        );
+                    }
                     node.remove();
                 });
             }
@@ -664,7 +697,7 @@ class ParagraphContent extends Format {
         if (!newList || !/ol|ul/.test(newList.tagName)) {
             const state = {
                 name: list.blockName,
-                meta: { ...(list as any).meta },
+                meta: { ...(list as TListBlock).meta },
                 children: [listItem.getState()],
             };
             newList = ScrollPage.loadBlock(state.name).create(muya, state);
@@ -676,10 +709,13 @@ class ParagraphContent extends Format {
 
         listItem.remove();
 
-        const cursorBlock = ((newList as Parent).lastChild as any)
-            .find(offset)
-            .firstContentInDescendant();
-        cursorBlock.setCursor(start.offset, end.offset, true);
+        // newList.lastChild is the just-appended list-item (a Parent) at
+        // runtime; find/firstContentInDescendant live on Parent. find()
+        // returns the matched TreeNode (which is itself a Parent at runtime
+        // for nested-list cases).
+        const matched = ((newList as Parent).lastChild as Parent).find(offset) as Parent | undefined;
+        const cursorBlock = matched?.firstContentInDescendant();
+        cursorBlock?.setCursor(start.offset, end.offset, true);
     }
 
     override insertTab() {

--- a/packages/core/src/block/content/tableCell/__tests__/tabHandler.spec.ts
+++ b/packages/core/src/block/content/tableCell/__tests__/tabHandler.spec.ts
@@ -12,7 +12,13 @@ import TableCellContent from '../index';
 // real DOM). The handler only reads `event.shiftKey` and calls
 // `previousContentInContext` / `nextContentInContext` on `this`.
 
-function makeFakeCell(prev: any, next: any) {
+// Structural neighbour shape — the table-cell tab handler only calls
+// `setCursor` on whatever `prev`/`next` resolves to.
+interface IFakeNeighbour {
+    setCursor: ReturnType<typeof vi.fn>;
+}
+
+function makeFakeCell(prev: IFakeNeighbour | null, next: IFakeNeighbour | null) {
     return {
         nextContentInContext: vi.fn(() => next),
         previousContentInContext: vi.fn(() => prev),

--- a/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
+++ b/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
@@ -133,7 +133,7 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
         // caller can `setCursor(0, 0)` on it.
         expect(result).toBeTruthy();
         expect(result).toBe(fake.inner.rows[2].cells[0].firstChild);
-        expect((fake.inner.rows[1] as any).removed).toBe(true);
+        expect((fake.inner.rows[1] as IFakeRow & { removed?: boolean }).removed).toBe(true);
     });
 
     it('falls back to the previous row\'s first cell when the last row is removed', () => {
@@ -145,7 +145,7 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
         );
 
         expect(result).toBe(fake.inner.rows[1].cells[0].firstChild);
-        expect((fake.inner.rows[2] as any).removed).toBe(true);
+        expect((fake.inner.rows[2] as IFakeRow & { removed?: boolean }).removed).toBe(true);
     });
 
     it('removes the whole table when the only row is removed, and returns null without an outside fallback', () => {
@@ -164,7 +164,9 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
     it('returns the next outside-of-table content when the only row is removed (Copilot PR-7b review follow-up)', () => {
         const fake = makeFakeTable(1, 3);
         const outsideContent = { setCursor: vi.fn() };
-        fake.nextContentInContext = vi.fn(() => outsideContent as any);
+        // The outsideContent only implements `setCursor`; cast to the
+        // structural return type the production code expects.
+        fake.nextContentInContext = vi.fn(() => outsideContent as unknown as null);
 
         const result = Table.prototype.removeRow.call(
             fake as unknown as Table,
@@ -179,7 +181,7 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
     it('falls back to previousContentInContext when there is no next content outside the table', () => {
         const fake = makeFakeTable(1, 3);
         const prevOutside = { setCursor: vi.fn() };
-        fake.previousContentInContext = vi.fn(() => prevOutside as any);
+        fake.previousContentInContext = vi.fn(() => prevOutside as unknown as null);
 
         const result = Table.prototype.removeRow.call(
             fake as unknown as Table,
@@ -199,7 +201,7 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
 
         expect(result).toBeUndefined();
         for (const row of fake.inner.rows)
-            expect((row as any).removed).not.toBe(true);
+            expect((row as IFakeRow & { removed?: boolean }).removed).not.toBe(true);
     });
 });
 
@@ -220,8 +222,8 @@ describe('table.removeColumn — returns surviving cell content for cursor place
         );
 
         expect(result).toBe(expectedSurvivor);
-        expect((removedCol1Row0 as any).removed).toBe(true);
-        expect((removedCol1Row1 as any).removed).toBe(true);
+        expect((removedCol1Row0 as IFakeCell & { removed?: boolean }).removed).toBe(true);
+        expect((removedCol1Row1 as IFakeCell & { removed?: boolean }).removed).toBe(true);
     });
 
     it('falls back to the previous-cell content when the last column is removed', () => {
@@ -252,7 +254,9 @@ describe('table.removeColumn — returns surviving cell content for cursor place
     it('returns the next outside-of-table content when the only column is removed (Copilot PR-7b review follow-up)', () => {
         const fake = makeFakeTable(2, 1);
         const outsideContent = { setCursor: vi.fn() };
-        fake.nextContentInContext = vi.fn(() => outsideContent as any);
+        // The outsideContent only implements `setCursor`; cast to the
+        // structural return type the production code expects.
+        fake.nextContentInContext = vi.fn(() => outsideContent as unknown as null);
 
         const result = Table.prototype.removeColumn.call(
             fake as unknown as Table,
@@ -275,7 +279,7 @@ describe('table.removeColumn — returns surviving cell content for cursor place
         // No cells removed.
         for (const row of fake.inner.rows) {
             for (const cell of row.cells)
-                expect((cell as any).removed).not.toBe(true);
+                expect((cell as IFakeCell & { removed?: boolean }).removed).not.toBe(true);
         }
     });
 });

--- a/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
+++ b/packages/core/src/block/gfm/table/__tests__/removeRowColumn.spec.ts
@@ -102,6 +102,12 @@ function makeTableInner(rowCount: number, cellCount: number): IFakeTableInner {
     };
 }
 
+// Stubbed return type for the contextual neighbour lookups; matches the
+// production `Table.nextContentInContext` signature (`Nullable<Content>`)
+// so per-test overrides can return a structurally-typed fake without an
+// `as unknown as null` lie.
+type TNeighbourReturn = ReturnType<Table['nextContentInContext']>;
+
 function makeFakeTable(rowCount: number, cellCount: number) {
     const inner = makeTableInner(rowCount, cellCount);
     return {
@@ -113,8 +119,8 @@ function makeFakeTable(rowCount: number, cellCount: number) {
         // on `this` before `this.remove()`. Stub both to return null in the
         // base fixture; specific tests override to assert the outside-
         // content fallback.
-        nextContentInContext: vi.fn(() => null),
-        previousContentInContext: vi.fn(() => null),
+        nextContentInContext: vi.fn((): TNeighbourReturn => null),
+        previousContentInContext: vi.fn((): TNeighbourReturn => null),
         inner,
     };
 }
@@ -164,9 +170,11 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
     it('returns the next outside-of-table content when the only row is removed (Copilot PR-7b review follow-up)', () => {
         const fake = makeFakeTable(1, 3);
         const outsideContent = { setCursor: vi.fn() };
-        // The outsideContent only implements `setCursor`; cast to the
-        // structural return type the production code expects.
-        fake.nextContentInContext = vi.fn(() => outsideContent as unknown as null);
+        // The outsideContent only implements `setCursor` — enough for the
+        // production code, which only calls setCursor on the returned
+        // value. Cast to the real production return type rather than `null`
+        // so the stub stays honest about what it's pretending to be.
+        fake.nextContentInContext = vi.fn(() => outsideContent as unknown as TNeighbourReturn);
 
         const result = Table.prototype.removeRow.call(
             fake as unknown as Table,
@@ -181,7 +189,7 @@ describe('table.removeRow — returns surviving cell content for cursor placemen
     it('falls back to previousContentInContext when there is no next content outside the table', () => {
         const fake = makeFakeTable(1, 3);
         const prevOutside = { setCursor: vi.fn() };
-        fake.previousContentInContext = vi.fn(() => prevOutside as unknown as null);
+        fake.previousContentInContext = vi.fn(() => prevOutside as unknown as TNeighbourReturn);
 
         const result = Table.prototype.removeRow.call(
             fake as unknown as Table,
@@ -254,9 +262,11 @@ describe('table.removeColumn — returns surviving cell content for cursor place
     it('returns the next outside-of-table content when the only column is removed (Copilot PR-7b review follow-up)', () => {
         const fake = makeFakeTable(2, 1);
         const outsideContent = { setCursor: vi.fn() };
-        // The outsideContent only implements `setCursor`; cast to the
-        // structural return type the production code expects.
-        fake.nextContentInContext = vi.fn(() => outsideContent as unknown as null);
+        // The outsideContent only implements `setCursor` — enough for the
+        // production code, which only calls setCursor on the returned
+        // value. Cast to the real production return type rather than `null`
+        // so the stub stays honest about what it's pretending to be.
+        fake.nextContentInContext = vi.fn(() => outsideContent as unknown as TNeighbourReturn);
 
         const result = Table.prototype.removeColumn.call(
             fake as unknown as Table,

--- a/packages/core/src/block/gfm/table/index.ts
+++ b/packages/core/src/block/gfm/table/index.ts
@@ -110,7 +110,9 @@ class Table extends Parent {
     }
 
     queryBlock(path: TBlockPath) {
-        return (this.firstChild as any).queryBlock(path);
+        // Table's only child at runtime is `TableInner` (the body wrapper),
+        // which extends the queryBlock mixin and is always present.
+        return (this.firstChild as Parent & { queryBlock: (p: TBlockPath) => Parent | Content | undefined }).queryBlock(path);
     }
 
     override empty() {

--- a/packages/core/src/block/mixins/containerQueryBlock.ts
+++ b/packages/core/src/block/mixins/containerQueryBlock.ts
@@ -15,9 +15,16 @@ class IContainerQueryBlock {
             return this;
 
         const p = path.shift() as number;
-        const block = this.find(p);
+        // `find(p)` returns either a Parent (which the mixin extends with
+        // `queryBlock`) or a Content leaf. Recursion only happens when more
+        // path segments remain — by that point the runtime contract is
+        // that the block is a Parent. Express the queryable shape directly
+        // instead of casting to `any`.
+        const block = this.find(p) as (Parent & { queryBlock: (p: TBlockPath) => Parent | Content | undefined }) | Content;
 
-        return block && path.length ? (block as any).queryBlock(path) : block;
+        return block && path.length && 'queryBlock' in block
+            ? block.queryBlock(path)
+            : block;
     }
 }
 

--- a/packages/core/src/block/scrollPage/index.ts
+++ b/packages/core/src/block/scrollPage/index.ts
@@ -2,7 +2,8 @@ import type { Muya } from '../../muya';
 import type { TState } from '../../state/types';
 import type { Nullable } from '../../types';
 import type Content from '../base/content';
-import type { TBlockPath } from '../types';
+import type TreeNode from '../base/treeNode';
+import type { IConstructor, TBlockPath } from '../types';
 import { BLOCK_DOM_PROPERTY } from '../../config';
 import { isMouseEvent } from '../../utils';
 import logger from '../../utils/logger';
@@ -20,20 +21,31 @@ export class ScrollPage extends Parent {
 
     static override blockName = 'scrollpage';
 
-    static registeredBlocks = new Map();
+    // Registry of block constructors keyed by their static blockName.
+    // Stored as Parent constructors — the overwhelming majority of
+    // call sites do `loadBlock(...).create(...).append(child)`, which only
+    // makes sense for Parent. Content leaves register themselves through
+    // their containing Parent's create flow and don't go through
+    // `loadBlock(...).create()` externally.
+    static registeredBlocks = new Map<string, IConstructor<Parent>>();
 
-    static register(Block: any) {
+    static register(Block: IConstructor<TreeNode>) {
         const { blockName } = Block;
-        this.registeredBlocks.set(blockName, Block);
+        this.registeredBlocks.set(blockName, Block as IConstructor<Parent>);
     }
 
-    static loadBlock(blockName: string) {
+    // Returns the registered constructor. Asserts non-undefined for
+    // callers (the registry is populated by `registerBlocks()` once at
+    // `editor.init()` time, and `loadBlock` runs strictly after init.).
+    // Mismatched names hit the warn branch and the caller crashes at
+    // `.create()` — matches the original loose contract.
+    static loadBlock(blockName: string): IConstructor<Parent> {
         const block = this.registeredBlocks.get(blockName);
 
         if (!block)
             debug.warn(`block:${blockName} is not existed.`);
 
-        return block;
+        return block as IConstructor<Parent>;
     }
 
     static create(muya: Muya, state: TState[]) {
@@ -98,8 +110,8 @@ export class ScrollPage extends Parent {
             return this;
 
         const p = path.shift() as number;
-        const block = this.find(p) as Parent;
-        return block && path.length ? (block as any).queryBlock(path) : block;
+        const block = this.find(p) as Parent & { queryBlock: (p: TBlockPath) => Parent | Content | undefined };
+        return block && path.length ? block.queryBlock(path) : block;
     }
 
     updateRefLinkAndImage(label: string) {

--- a/packages/core/src/block/types.ts
+++ b/packages/core/src/block/types.ts
@@ -1,9 +1,21 @@
 import type { Muya } from '../muya';
 
+// Block constructor signature stored in `ScrollPage.registeredBlocks` and
+// returned from `ScrollPage.loadBlock`. The registry holds heterogeneous
+// block kinds; each concrete subclass ships its own `static create(muya,
+// state)` where `state` narrows to the corresponding I…State interface.
+// `create` returns `any` so the registry-driven dispatcher chain
+// (`loadBlock(...).create(muya, state).firstContentInDescendant()…`)
+// stays usable across both Parent and Content shapes without forcing
+// every call site to cast. Both `any` slots below are sanctioned escape
+// hatches for this dispatcher pattern. The constructor uses `never[]` in
+// the args (contravariant) so it accepts any concrete subclass signature
+// like `new (muya: Muya, state: IAtxHeadingState)`.
 export interface IConstructor<T> {
     blockName: string;
-    create: (muya: Muya, state: any) => T;
-    new (muya: Muya): T;
+    // eslint-disable-next-line ts/no-explicit-any
+    create: (muya: Muya, state: any) => any;
+    new (...args: never[]): T;
 }
 
 export type TBlockPath = (string | number)[];

--- a/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
+++ b/packages/core/src/clipboard/__tests__/getClipboardData.spec.ts
@@ -1,3 +1,4 @@
+import type Content from '../../block/base/content';
 import type { Muya } from '../../muya';
 import { describe, expect, it, vi } from 'vitest';
 
@@ -31,12 +32,14 @@ function selectionOver(
     end: number,
     blockName: string = 'paragraph.content',
 ) {
+    // The fake block only exposes the two fields getClipboardData reads.
+    const block = { text, blockName } as unknown as Content;
     return {
         isSelectionInSameBlock: true,
         anchor: { offset: begin },
         focus: { offset: end },
-        anchorBlock: { text, blockName } as any,
-        focusBlock: { text, blockName } as any,
+        anchorBlock: block,
+        focusBlock: block,
     };
 }
 

--- a/packages/core/src/clipboard/__tests__/mergePasteIntoHeading.spec.ts
+++ b/packages/core/src/clipboard/__tests__/mergePasteIntoHeading.spec.ts
@@ -1,5 +1,19 @@
+import type Content from '../../block/base/content';
+import type Parent from '../../block/base/parent';
+import type { TState } from '../../state/types';
 import { describe, expect, it } from 'vitest';
 import { mergePasteIntoHeading } from '../mergePasteIntoHeading';
+
+// Narrow casts shared by every test below. The helper under test only
+// touches `text` / `update()` on the anchor and `blockName` on the wrapper,
+// so the fake objects intentionally don't satisfy the full Content / Parent
+// surface — `as unknown as Content` (etc.) makes the assertion explicit.
+function asContent(block: FakeContent): Content {
+    return block as unknown as Content;
+}
+function asParentWithBlockName(blockName: string): Parent {
+    return { blockName } as unknown as Parent;
+}
 
 // Regression for marktext commit 1c42555a (#671):
 // "allow pasting multi-line text into a heading".
@@ -40,9 +54,9 @@ describe('mergePasteIntoHeading', () => {
         ];
 
         const remaining = mergePasteIntoHeading(
-            heading as any,
-            { blockName: 'atx-heading' } as any,
-            states as any,
+            asContent(heading),
+            asParentWithBlockName('atx-heading'),
+            states as TState[],
             { startOffset: 5, endOffset: 5 },
         );
 
@@ -59,9 +73,9 @@ describe('mergePasteIntoHeading', () => {
         ];
 
         const remaining = mergePasteIntoHeading(
-            heading as any,
-            { blockName: 'setext-heading' } as any,
-            states as any,
+            asContent(heading),
+            asParentWithBlockName('setext-heading'),
+            states as TState[],
             { startOffset: 5, endOffset: 5 },
         );
 
@@ -77,9 +91,9 @@ describe('mergePasteIntoHeading', () => {
         ];
 
         const remaining = mergePasteIntoHeading(
-            heading as any,
-            { blockName: 'atx-heading' } as any,
-            states as any,
+            asContent(heading),
+            asParentWithBlockName('atx-heading'),
+            states as TState[],
             { startOffset: 6, endOffset: 9 },
         );
 
@@ -95,9 +109,9 @@ describe('mergePasteIntoHeading', () => {
         ];
 
         const remaining = mergePasteIntoHeading(
-            para as any,
-            { blockName: 'paragraph' } as any,
-            states as any,
+            asContent(para),
+            asParentWithBlockName('paragraph'),
+            states as TState[],
             { startOffset: 3, endOffset: 3 },
         );
 
@@ -114,9 +128,9 @@ describe('mergePasteIntoHeading', () => {
         ];
 
         const remaining = mergePasteIntoHeading(
-            heading as any,
-            { blockName: 'atx-heading' } as any,
-            states as any,
+            asContent(heading),
+            asParentWithBlockName('atx-heading'),
+            states as TState[],
             { startOffset: 5, endOffset: 5 },
         );
 
@@ -129,8 +143,8 @@ describe('mergePasteIntoHeading', () => {
         const heading = content('Title');
 
         const remaining = mergePasteIntoHeading(
-            heading as any,
-            { blockName: 'atx-heading' } as any,
+            asContent(heading),
+            asParentWithBlockName('atx-heading'),
             [],
             { startOffset: 5, endOffset: 5 },
         );

--- a/packages/core/src/clipboard/index.ts
+++ b/packages/core/src/clipboard/index.ts
@@ -1,7 +1,14 @@
 import type Content from '../block/base/content';
 import type Parent from '../block/base/parent';
 import type { Muya } from '../muya';
-import type { IBlockQuoteState, IParagraphState } from '../state/types';
+import type {
+    IBlockQuoteState,
+    IBulletListState,
+    IOrderListState,
+    IParagraphState,
+    ITaskListState,
+    TState,
+} from '../state/types';
 import type { Nullable } from '../types';
 import { fromEvent, merge } from 'rxjs';
 import CodeBlockContent from '../block/content/codeBlockContent';
@@ -195,14 +202,20 @@ class Clipboard {
                     = outBlock!.blockName === 'task-list' ? 'task-list-item' : 'list-item';
                 const listItem = block.farthestBlock(listItemBlockName);
                 const offset = (outBlock as Parent).offset(listItem!);
-                const { name, meta, children } = (outBlock as any).getState();
+                // outBlock is a list parent at runtime; getState() returns a
+                // bullet/order/task-list state whose `children` is an
+                // IListItemState/ITaskListItemState array. The intermediate
+                // `name`/`meta`/`children` extraction is loosely typed so we
+                // can spread it back into a copyState entry without
+                // re-deriving the discriminated union here.
+                const listState = (outBlock as Parent).getState() as IBulletListState | IOrderListState | ITaskListState;
                 copyState.push({
-                    name,
-                    meta,
-                    children: children.filter((_: unknown, index: number) =>
+                    name: listState.name,
+                    meta: listState.meta,
+                    children: listState.children.filter((_, index) =>
                         position === 'start' ? index >= offset : index <= offset,
                     ),
-                });
+                } as TState);
             }
             else {
                 if (position === 'start' && startOffset < startBlock.text.length) {
@@ -242,15 +255,14 @@ class Clipboard {
                 );
                 const minOffset = Math.min(anchorOffset, focusOffset);
                 const maxOffset = Math.max(anchorOffset, focusOffset);
-                const { name, meta, children } = (anchorOutMostBlock as any).getState();
+                const listState = (anchorOutMostBlock as Parent).getState() as IBulletListState | IOrderListState | ITaskListState;
                 copyState.push({
-                    name,
-                    meta,
-                    children: children.filter(
-                        (_: unknown, index: number) =>
-                            index >= minOffset && index <= maxOffset,
+                    name: listState.name,
+                    meta: listState.meta,
+                    children: listState.children.filter((_, index) =>
+                        index >= minOffset && index <= maxOffset,
                     ),
-                });
+                } as TState);
             }
         }
         else {
@@ -413,7 +425,7 @@ class Clipboard {
                             this.muya,
                             state,
                         );
-                        (item as any).replaceWith(newListItem);
+                        (item as Parent).replaceWith(newListItem);
                         cursorBlock = newListItem.firstContentInDescendant();
                         cursorOffset = 0;
                     }
@@ -498,7 +510,7 @@ class Clipboard {
                             this.muya,
                             state,
                         );
-                        (item as any).replaceWith(newListItem);
+                        (item as Parent).replaceWith(newListItem);
                         cursorBlock = newListItem.firstContentInDescendant();
                         cursorOffset = 0;
                     }
@@ -637,7 +649,7 @@ class Clipboard {
                 // Remove empty paragraph when paste.
                 if (
                     originWrapperBlock?.blockName === 'paragraph'
-                    && (originWrapperBlock.getState() as any).text === ''
+                    && (originWrapperBlock.getState() as IParagraphState).text === ''
                 ) {
                     originWrapperBlock.remove();
                 }
@@ -668,7 +680,12 @@ class Clipboard {
                         anchorBlock.outContainer.blockName,
                     )
                 ) {
-                    (anchorBlock.outContainer.attachments.head as any).update(
+                    // The attachments list of html-block / math-block /
+                    // diagram blocks always opens with the render preview
+                    // node, which exposes an `update(text)` method. The
+                    // LinkedList itself is typed loosely (TreeNode), hence
+                    // the narrow structural cast here.
+                    (anchorBlock.outContainer.attachments.head as unknown as { update: (text: string) => void }).update(
                         anchorBlock.text,
                     );
                 }

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -372,7 +372,7 @@ export const punctuation = [
     '}',
     '~',
 ];
-// export const isInElectron = (window.process as any)?.type === "renderer";
+// Electron detection (kept for reference; renderer-process check).
 export const IMAGE_EXT_REG = /\.(jpeg|jpg|png|gif|svg|webp)(?=\?|$)/i;
 export const isFirefox
     = typeof navigator !== 'undefined' && navigator.userAgent.includes('Firefox');
@@ -434,7 +434,13 @@ export const DEFAULT_TURNDOWN_CONFIG = {
     strongDelimiter: '**', // ** or __
     linkStyle: 'inlined',
     linkReferenceStyle: 'full',
-    blankReplacement(_content: unknown, node: any, _options: unknown) {
+    blankReplacement(
+        _content: unknown,
+        // Turndown passes its internal node object: a real DOM Element
+        // plus the augmented `isBlock` flag the library adds when walking.
+        node: Element & { isBlock?: boolean },
+        _options: unknown,
+    ) {
         if (node && node.classList.contains('mu-soft-line-break'))
             return LINE_BREAK;
         else if (node && node.classList.contains('mu-hard-line-break'))

--- a/packages/core/src/editor/__tests__/linkMouseEvents.spec.ts
+++ b/packages/core/src/editor/__tests__/linkMouseEvents.spec.ts
@@ -31,9 +31,15 @@ afterEach(() => {
     document.body.innerHTML = '';
 });
 
-function captureEmits(eventCenter: EventCenter) {
-    const emits: any[] = [];
-    eventCenter.subscribe('muya-link-tools', (payload: any) => emits.push(payload));
+interface ILinkToolsPayload {
+    reference: HTMLElement;
+    linkInfo?: { href?: string; raw?: string };
+    type: 'preview' | 'edit';
+}
+
+function captureEmits(eventCenter: EventCenter): ILinkToolsPayload[] {
+    const emits: ILinkToolsPayload[] = [];
+    eventCenter.subscribe('muya-link-tools', (payload: ILinkToolsPayload) => emits.push(payload));
     return emits;
 }
 
@@ -56,7 +62,7 @@ describe('linkMouseEvents — dispatches muya-link-tools on hover', () => {
         link.dataset.raw = '[hi](https://x.com)';
         link.dataset.start = '0';
         link.dataset.end = '19';
-        (link as any).href = 'https://x.com';
+        (link as HTMLElement & { href: string }).href = 'https://x.com';
         link.textContent = 'hi';
         domNode.appendChild(marker);
         domNode.appendChild(link);
@@ -189,7 +195,7 @@ describe('linkMouseEvents — dispatches muya-link-tools on hover', () => {
         const link = document.createElement('span');
         link.classList.add('mu-inline-rule', 'mu-link');
         link.dataset.raw = '[hi](https://x.com)';
-        (link as any).href = 'https://x.com';
+        (link as HTMLElement & { href: string }).href = 'https://x.com';
         // Inner spans like emphasis/strong that text children get wrapped in.
         const innerA = document.createElement('em');
         innerA.textContent = 'hi-em';

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -1,6 +1,8 @@
+import type { JSONOp, JSONOpComponent, JSONOpList } from 'ot-json1';
 import type Content from '../block/base/content';
 import type Format from '../block/base/format';
 import type { Muya } from '../muya';
+import type { ISelection } from '../selection/types';
 import type { TState } from '../state/types';
 import type { Nullable } from '../types';
 import * as otText from 'ot-text-unicode';
@@ -162,17 +164,41 @@ export class Editor {
         firstLeafBlock.setCursor(0, 0, needUpdated);
     }
 
-    updateContents(operations: any, selection: any, source: any) {
+    updateContents(operations: JSONOp, selection: Nullable<ISelection>, source: string) {
         const { muya } = this;
-        this.jsonState.dispatch(operations, source);
+        // `dispatch` takes JSONOpList. ot-json1's no-op (null) is bailed
+        // out below before the walker runs; null is still forwarded to
+        // dispatch so listeners see the (no-op) json-change event.
+        this.jsonState.dispatch(operations as JSONOpList, source);
 
         // Codes bellow are copy from `ot-json1.apply` and modified.
         if (operations === null)
             return;
 
+        // The pick/drop walkers operate on live block-tree nodes (ScrollPage,
+        // Parent, Content). The tree's instance methods (queryBlock, find,
+        // insertBefore, etc.) are not all exposed on a single TS type, and
+        // ot-json1 op descents are dynamically shaped — so we type these as
+        // BlockNode (loose structural alias) inside the inner walkers and let
+        // the runtime branches do the actual narrowing.
+        type BlockNode = {
+            queryBlock?: (path: (string | number)[]) => BlockNode | undefined;
+            find?: (key: number | string) => BlockNode;
+            remove?: (source: string) => void;
+            replaceWith?: (newBlock: BlockNode, source: string) => void;
+            insertBefore?: (newBlock: BlockNode, ref: BlockNode, source: string) => void;
+            update?: (value?: unknown, source?: string) => void;
+            blockName?: string;
+            align?: string;
+            _text?: string;
+            text?: string;
+            meta?: { lang?: string; type?: string };
+            parent?: BlockNode;
+        } | undefined;
+
         // Phase 1: Pick. Returns updated subDocument.
-        function pick(subDoc: any, descent: any) {
-            const stack = [];
+        function pick(subDoc: BlockNode, descent: JSONOpList): BlockNode {
+            const stack: BlockNode[] = [];
 
             let i = 0;
 
@@ -184,12 +210,12 @@ export class Editor {
                     continue;
                 stack.push(subDoc);
                 // Its valid to descend into a null space - just we can't pick there.
-                subDoc = subDoc == null ? undefined : subDoc.queryBlock([d]);
+                subDoc = subDoc == null ? undefined : subDoc.queryBlock?.([d]);
             }
 
             // Children. These need to be traversed in reverse order here.
             for (let j = descent.length - 1; j >= i; j--)
-                subDoc = pick(subDoc, descent[j]);
+                subDoc = pick(subDoc, descent[j] as JSONOpList);
 
             // Then back again.
             for (--i; i >= 0; i--) {
@@ -198,24 +224,25 @@ export class Editor {
                     const container = stack.pop();
                     if (
                         subDoc
-                        === (container == null ? undefined : container.queryBlock([d]))
+                        === (container == null ? undefined : container.queryBlock?.([d as string | number]))
                     ) {
                         subDoc = container;
                     }
                     else {
                         if (subDoc === undefined) {
                             // TODO: handler typeof d === 'string'
-                            typeof d === 'number' && container.find(d).remove('api');
+                            if (typeof d === 'number')
+                                container?.find?.(d)?.remove?.('api');
                             subDoc = container;
                         }
                         else {
-                            typeof d === 'number'
-                            && container.find(d).replaceWith(subDoc, 'api');
+                            if (typeof d === 'number')
+                                container?.find?.(d)?.replaceWith?.(subDoc, 'api');
                             subDoc = container;
                         }
                     }
                 }
-                else if (hasPick(d)) {
+                else if (!Array.isArray(d) && hasPick(d)) {
                     subDoc = undefined;
                 }
             }
@@ -223,24 +250,29 @@ export class Editor {
             return subDoc;
         }
 
-        const snapshot = pick(this.scrollPage, operations);
+        const snapshot = pick(this.scrollPage as unknown as BlockNode, operations);
 
-        function drop(root: any, descent: any) {
+        function drop(root: BlockNode, descent: JSONOpList): BlockNode {
             let subDoc = root;
             let i = 0; // For reading
             let m = 0;
-            const rootContainer = { root }; // This is an avoidable allocation.
-            let container: any = rootContainer;
-            let key = 'root'; // For writing
+            const rootContainer: { root: BlockNode } = { root }; // This is an avoidable allocation.
+            let container: BlockNode | { root: BlockNode } = rootContainer;
+            let key: string | number = 'root'; // For writing
 
             function mut() {
                 for (; m < i; m++) {
                     const d = descent[m];
                     if (typeof d === 'object')
                         continue;
-                    container
-                        = key === 'root' ? container[key] : container.queryBlock([key]);
-                    key = d;
+                    if (key === 'root') {
+                        const wrap = container as { root: BlockNode };
+                        container = wrap.root;
+                    }
+                    else {
+                        container = (container as BlockNode)?.queryBlock?.([key]);
+                    }
+                    key = d as string | number;
                 }
             }
 
@@ -252,24 +284,32 @@ export class Editor {
                     if (child !== subDoc && child !== undefined) {
                         mut();
                         // It maybe never go into this if statement.
-                        subDoc = container[key] = child;
+                        if (key === 'root')
+                            (container as { root: BlockNode }).root = child;
+                        else
+                            (container as Record<string, BlockNode>)[key] = child;
+                        subDoc = child;
                     }
                 }
                 else if (typeof d === 'object') {
-                    if (d.i !== undefined) {
+                    const comp = d as JSONOpComponent;
+                    if (comp.i !== undefined) {
                         // Insert
                         mut();
-                        const ref = container.find(key);
+                        const cur = container as BlockNode;
+                        const ref = cur?.find?.(key);
                         if (typeof key === 'number') {
-                            const newBlock = ScrollPage.loadBlock(d.i.name).create(muya, d.i);
-                            container.insertBefore(newBlock, ref, 'api');
+                            const insertedState = comp.i as { name: string };
+                            const newBlock = ScrollPage.loadBlock(insertedState.name).create(muya, insertedState) as unknown as BlockNode;
+                            if (cur && ref && newBlock)
+                                cur.insertBefore?.(newBlock, ref, 'api');
 
                             subDoc = newBlock;
                         }
                         else {
                             switch (key) {
                                 case 'checked': {
-                                    ref.update(d.i, 'api');
+                                    ref?.update?.(comp.i, 'api');
                                     break;
                                 }
 
@@ -284,29 +324,32 @@ export class Editor {
                         }
                     }
 
-                    if (d.es) {
+                    if (comp.es) {
                         // Edit. Ok because its illegal to drop inside mixed region
                         mut();
-                        if (subDoc.blockName === 'table.cell') {
-                            subDoc.align = otText.type.apply(subDoc.align, d.es);
+                        const sd = subDoc!;
+                        if (sd.blockName === 'table.cell') {
+                            sd.align = otText.type.apply(sd.align ?? '', comp.es) as string;
                         }
-                        else if (subDoc.blockName === 'language-input') {
-                            subDoc._text = otText.type.apply(subDoc.text, d.es);
-                            subDoc.parent.meta.lang = subDoc.text;
-                            subDoc.update();
+                        else if (sd.blockName === 'language-input') {
+                            sd._text = otText.type.apply(sd.text ?? '', comp.es) as string;
+                            if (sd.parent?.meta)
+                                sd.parent.meta.lang = sd.text;
+                            sd.update?.();
                         }
-                        else if (subDoc.blockName === 'code-block') {
+                        else if (sd.blockName === 'code-block') {
                             // Handle modify code block type.
-                            subDoc.meta.type = otText.type.apply(subDoc.meta.type, d.es);
+                            if (sd.meta)
+                                sd.meta.type = otText.type.apply(sd.meta.type ?? '', comp.es) as string;
                         }
                         else {
-                            subDoc._text = otText.type.apply(subDoc.text, d.es);
-                            subDoc.update();
+                            sd._text = otText.type.apply(sd.text ?? '', comp.es) as string;
+                            sd.update?.();
                         }
                     }
                 }
                 else {
-                    subDoc = subDoc != null ? subDoc.queryBlock([d]) : undefined;
+                    subDoc = subDoc != null ? subDoc.queryBlock?.([d]) : undefined;
                 }
             }
 

--- a/packages/core/src/editor/index.ts
+++ b/packages/core/src/editor/index.ts
@@ -166,10 +166,10 @@ export class Editor {
 
     updateContents(operations: JSONOp, selection: Nullable<ISelection>, source: string) {
         const { muya } = this;
-        // `dispatch` takes JSONOpList. ot-json1's no-op (null) is bailed
-        // out below before the walker runs; null is still forwarded to
-        // dispatch so listeners see the (no-op) json-change event.
-        this.jsonState.dispatch(operations as JSONOpList, source);
+        // ot-json1 no-op (`null`) is forwarded to dispatch — JSONState
+        // short-circuits internally so listeners still see a json-change
+        // event for the no-op.
+        this.jsonState.dispatch(operations, source);
 
         // Codes bellow are copy from `ot-json1.apply` and modified.
         if (operations === null)

--- a/packages/core/src/event/types.ts
+++ b/packages/core/src/event/types.ts
@@ -1,3 +1,10 @@
+// Event payloads are heterogeneous and per-event-name; the emitter does
+// `listener(...args)` with arbitrary args and the receiver destructures an
+// event-specific shape. Typed alternatives (`unknown[]` / `never[]`) force
+// every existing consumer to widen or narrow, which is invasive enough to
+// be its own follow-up. Keep the existing `any[]` here; future work can
+// introduce a typed event map.
+// eslint-disable-next-line ts/no-explicit-any
 export type Listener = (...args: any[]) => void;
 
 export interface IEvent {

--- a/packages/core/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
+++ b/packages/core/src/inlineRenderer/__tests__/commonmarkExamples.spec.ts
@@ -1,7 +1,18 @@
 // @vitest-environment happy-dom
 
+import type { ImageToken, LinkToken, StrongEmToken, SuperSubScriptToken, Token } from '../types';
 import { describe, expect, it } from 'vitest';
 import { tokenizer } from '../lexer';
+
+// Narrowing helpers — extract a specific token kind out of the inline Token
+// union by literal `type` field. Mirrors the runtime `find(t => t.type === X)`
+// shape so tests can drop their `as any` casts.
+function findByType<TType extends Token['type']>(
+    tokens: Token[],
+    type: TType,
+): Extract<Token, { type: TType }> | undefined {
+    return tokens.find(t => t.type === type) as Extract<Token, { type: TType }> | undefined;
+}
 
 // Defensive regression tests for the CommonMark 0.29 spec examples that the
 // legacy marktext inline lexer used to fail before commit 57cd04c5 (Apr 2019,
@@ -94,7 +105,7 @@ describe('inline lexer — reference link (marktext d9f64bab)', () => {
 describe('inline lexer — superscript/subscript (marktext 8e32838b)', () => {
     it('parses ^foo^ as a super_sub_script token with `^` marker', () => {
         const tokens = tokenizer('text^sup^');
-        const sup = tokens.find(t => t.type === 'super_sub_script') as any;
+        const sup = findByType(tokens, 'super_sub_script') as SuperSubScriptToken;
         expect(sup, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
         expect(sup.marker).toBe('^');
         expect(sup.content).toBe('sup');
@@ -102,7 +113,7 @@ describe('inline lexer — superscript/subscript (marktext 8e32838b)', () => {
 
     it('parses ~bar~ as a super_sub_script token with `~` marker', () => {
         const tokens = tokenizer('text~sub~');
-        const sub = tokens.find(t => t.type === 'super_sub_script') as any;
+        const sub = findByType(tokens, 'super_sub_script') as SuperSubScriptToken;
         expect(sub, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
         expect(sub.marker).toBe('~');
         expect(sub.content).toBe('sub');
@@ -151,7 +162,7 @@ describe('inline lexer — auto link (marktext c0853f64)', () => {
 describe('inline lexer — GFM link/image title (marktext ad5ddbf9)', () => {
     it('extracts title from a link with double-quoted title', () => {
         const tokens = tokenizer('[text](http://example.com "Example title")');
-        const link = tokens.find(t => t.type === 'link') as any;
+        const link = findByType(tokens, 'link') as LinkToken;
         expect(link).toBeDefined();
         expect(link.href).toBe('http://example.com');
         expect(link.title).toBe('Example title');
@@ -159,7 +170,7 @@ describe('inline lexer — GFM link/image title (marktext ad5ddbf9)', () => {
 
     it('extracts title from a link with single-quoted title', () => {
         const tokens = tokenizer(`[text](http://example.com 'Example title')`);
-        const link = tokens.find(t => t.type === 'link') as any;
+        const link = findByType(tokens, 'link') as LinkToken;
         expect(link).toBeDefined();
         expect(link.href).toBe('http://example.com');
         expect(link.title).toBe('Example title');
@@ -167,7 +178,7 @@ describe('inline lexer — GFM link/image title (marktext ad5ddbf9)', () => {
 
     it('extracts title from an image', () => {
         const tokens = tokenizer('![alt](http://example.com/x.png "Pic title")');
-        const image = tokens.find(t => t.type === 'image') as any;
+        const image = findByType(tokens, 'image') as ImageToken;
         expect(image).toBeDefined();
         expect(image.src).toBe('http://example.com/x.png');
         expect(image.title).toBe('Pic title');
@@ -175,7 +186,7 @@ describe('inline lexer — GFM link/image title (marktext ad5ddbf9)', () => {
 
     it('leaves title empty when the destination has no title', () => {
         const tokens = tokenizer('[text](http://example.com)');
-        const link = tokens.find(t => t.type === 'link') as any;
+        const link = findByType(tokens, 'link') as LinkToken;
         expect(link).toBeDefined();
         expect(link.href).toBe('http://example.com');
         expect(link.title).toBe('');
@@ -199,7 +210,7 @@ describe('inline lexer — repeated bold + inline_code (marktext d937fac0 / #107
         expect(strongs.length, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBe(3);
         // And each strong must contain a code span, not literal text.
         for (const strong of strongs) {
-            const innerTypes = (strong as any).children.map((c: any) => c.type);
+            const innerTypes = (strong as StrongEmToken).children.map(c => c.type);
             expect(innerTypes).toContain('inline_code');
         }
     });
@@ -220,14 +231,14 @@ describe('inline lexer — repeated bold + inline_code (marktext d937fac0 / #107
 describe('inline lexer — link / image dest with parens (marktext 57af8304 / #1169)', () => {
     it('parses image dest containing balanced parens correctly', () => {
         const tokens = tokenizer('![alt](path/to/(file).png)');
-        const image = tokens.find(t => t.type === 'image') as any;
+        const image = findByType(tokens, 'image') as ImageToken;
         expect(image, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
         expect(image.src).toBe('path/to/(file).png');
     });
 
     it('parses link dest containing balanced parens correctly', () => {
         const tokens = tokenizer('[text](path/to/(file).html)');
-        const link = tokens.find(t => t.type === 'link') as any;
+        const link = findByType(tokens, 'link') as LinkToken;
         expect(link, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
         expect(link.href).toBe('path/to/(file).html');
     });
@@ -239,12 +250,14 @@ describe('inline lexer — link / image dest with parens (marktext 57af8304 / #1
         // `findClosingBracket` walks the destination to the matching `)` so
         // the image stops at `first.png` and the rest stays as following text.
         const tokens = tokenizer('see ![alt](first.png) and also (parens) here');
-        const image = tokens.find(t => t.type === 'image') as any;
+        const image = findByType(tokens, 'image') as ImageToken;
         expect(image, `tokens: ${JSON.stringify(tokens.map(t => t.type))}`).toBeDefined();
         expect(image.src).toBe('first.png');
         // The trailing text — including the unrelated `(parens)` group — must
-        // remain outside the image token.
-        const joined = tokens.map(t => (t as any).raw ?? '').join('');
+        // remain outside the image token. Every Token in our union carries a
+        // `raw` field; `?? ''` defends against the rare extension token type
+        // that may omit it.
+        const joined = tokens.map(t => t.raw ?? '').join('');
         expect(joined).toContain('and also (parens) here');
         expect(image.raw).not.toContain('parens');
     });

--- a/packages/core/src/inlineRenderer/renderer/__tests__/image.spec.ts
+++ b/packages/core/src/inlineRenderer/renderer/__tests__/image.spec.ts
@@ -1,6 +1,10 @@
 // @vitest-environment happy-dom
 
+import type { VNode } from 'snabbdom';
+import type Format from '../../../block/base/format';
+import type { ICursor } from '../../../selection/types';
 import type { ImageToken } from '../../types';
+import type Renderer from '../index';
 import { describe, expect, it, vi } from 'vitest';
 import { h } from '../../../utils/snabbdom';
 import image from '../image';
@@ -62,9 +66,19 @@ function makeImageToken(overrides: Partial<ImageToken['attrs']> = {}): ImageToke
     } as unknown as ImageToken;
 }
 
-function getWrapperSelector(vnodes: any): string {
+function getWrapperSelector(vnodes: VNode | VNode[]): string {
     const arr = Array.isArray(vnodes) ? vnodes : [vnodes];
     return arr[0].sel as string;
+}
+
+// Narrow casts shared by every test: the fake renderer and block stubs
+// don't satisfy the full Renderer / Format / ICursor surface, but
+// `image()` only touches the loadImageAsync / urlMap / muya fields and
+// the token range.
+const fakeBlock = {} as unknown as Format;
+const fakeCursor = {} as unknown as ICursor;
+function asRenderer(r: IFakeRenderer): Renderer {
+    return r as unknown as Renderer;
 }
 
 describe('image renderer — small image class (marktext cb7be189)', () => {
@@ -78,8 +92,8 @@ describe('image renderer — small image class (marktext cb7be189)', () => {
         const token = makeImageToken();
 
         const out = image.call(
-            renderer as any,
-            { h, block: {} as any, token, cursor: {} as any },
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
         );
 
         expect(getWrapperSelector(out)).toContain('.mu-small-image');
@@ -95,8 +109,8 @@ describe('image renderer — small image class (marktext cb7be189)', () => {
         const token = makeImageToken();
 
         const out = image.call(
-            renderer as any,
-            { h, block: {} as any, token, cursor: {} as any },
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
         );
 
         expect(getWrapperSelector(out)).toContain('.mu-small-image');
@@ -112,8 +126,8 @@ describe('image renderer — small image class (marktext cb7be189)', () => {
         const token = makeImageToken();
 
         const out = image.call(
-            renderer as any,
-            { h, block: {} as any, token, cursor: {} as any },
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
         );
 
         expect(getWrapperSelector(out)).not.toContain('.mu-small-image');
@@ -127,8 +141,8 @@ describe('image renderer — small image class (marktext cb7be189)', () => {
         const token = makeImageToken();
 
         const out = image.call(
-            renderer as any,
-            { h, block: {} as any, token, cursor: {} as any },
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
         );
 
         expect(getWrapperSelector(out)).not.toContain('.mu-small-image');
@@ -142,8 +156,8 @@ describe('image renderer — small image class (marktext cb7be189)', () => {
         const token = makeImageToken();
 
         const out = image.call(
-            renderer as any,
-            { h, block: {} as any, token, cursor: {} as any },
+            asRenderer(renderer),
+            { h, block: fakeBlock, token, cursor: fakeCursor },
         );
 
         expect(getWrapperSelector(out)).not.toContain('.mu-small-image');

--- a/packages/core/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
+++ b/packages/core/src/inlineRenderer/renderer/__tests__/loadImageAsync.spec.ts
@@ -1,7 +1,14 @@
 // @vitest-environment happy-dom
 
+import type Renderer from '../index';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import loadImageAsync from '../loadImageAsync';
+
+// Narrow cast for the fake renderer used in every test below — it only
+// implements the two Map fields loadImageAsync touches.
+function asRenderer(r: FakeRenderer | { loadImageMap: Map<string, unknown>; urlMap: Map<string, string> }): Renderer {
+    return r as unknown as Renderer;
+}
 
 vi.mock('../../../utils/image', () => ({
     loadImage: vi.fn(() => new Promise(() => {})), // never resolves; we only test the sync decision
@@ -45,7 +52,7 @@ describe('loadImageAsync — failed cache should retry', () => {
         });
 
         const out = loadImageAsync.call(
-            r as unknown as Parameters<typeof loadImageAsync>[0] extends never ? never : any,
+            asRenderer(r),
             { isUnknownType: false, src: 'https://example.com/a.png' },
             {},
         );
@@ -68,7 +75,7 @@ describe('loadImageAsync — failed cache should retry', () => {
         });
 
         const out = loadImageAsync.call(
-            r as any,
+            asRenderer(r),
             { isUnknownType: false, src: 'https://example.com/b.png' },
             {},
         );
@@ -85,7 +92,7 @@ describe('loadImageAsync — failed cache should retry', () => {
         const r = makeRenderer();
 
         loadImageAsync.call(
-            r as any,
+            asRenderer(r),
             { isUnknownType: false, src: 'https://example.com/c.png' },
             {},
         );
@@ -111,7 +118,7 @@ describe('loadImageAsync — small image class on first load', () => {
 
     async function runLoad(loadResult: { url: string; width: number; height: number }) {
         const { loadImage } = await import('../../../utils/image');
-        (loadImage as any).mockResolvedValueOnce(loadResult);
+        vi.mocked(loadImage).mockResolvedValueOnce(loadResult as unknown as Awaited<ReturnType<typeof loadImage>>);
 
         const r = {
             loadImageMap: new Map(),
@@ -119,7 +126,7 @@ describe('loadImageAsync — small image class on first load', () => {
         };
 
         const { id } = loadImageAsync.call(
-            r as any,
+            asRenderer(r),
             { isUnknownType: false, src: 'https://example.com/fresh.png' },
             {},
         );

--- a/packages/core/src/inlineRenderer/renderer/delEmStrongFactory.ts
+++ b/packages/core/src/inlineRenderer/renderer/delEmStrongFactory.ts
@@ -29,12 +29,14 @@ export default function delEmStrongFac(
         = end - marker.length - token.backlash.length;
     const content: VNode[] = [
         ...token.children.reduce((acc: VNode[], to: Token) => {
-            const chunk = (this as any)[snakeToCamel(to.type)]({
+            // The original passed a `className` field here too, but receivers
+            // read `outerClass` — so the field was silently dropped under the
+            // previous `as any` cast. Preserve that behavior: don't propagate.
+            const chunk = this.dispatch(snakeToCamel(to.type), {
                 h,
                 cursor,
                 block,
                 token: to,
-                className,
             });
 
             return Array.isArray(chunk) ? [...acc, ...chunk] : [...acc, chunk];

--- a/packages/core/src/inlineRenderer/renderer/htmlTag.ts
+++ b/packages/core/src/inlineRenderer/renderer/htmlTag.ts
@@ -37,12 +37,15 @@ export default function htmlTag(
     const anchor
         = Array.isArray(children) && children.length && tag !== 'ruby' // important
             ? children.reduce((acc: VNode[], to: Token) => {
-                    const chunk = (this as any)[snakeToCamel(to.type)]({
+                    // The original passed a `className` field here too, but
+                    // receivers read `outerClass` — so the field was
+                    // silently dropped under the previous `as any` cast.
+                    // Preserve that runtime behavior: don't propagate it.
+                    const chunk = this.dispatch(snakeToCamel(to.type), {
                         h,
                         cursor,
                         block,
                         token: to,
-                        className,
                     });
 
                     return Array.isArray(chunk) ? [...acc, ...chunk] : [...acc, chunk];

--- a/packages/core/src/inlineRenderer/renderer/index.ts
+++ b/packages/core/src/inlineRenderer/renderer/index.ts
@@ -4,7 +4,7 @@ import type Format from '../../block/base/format';
 import type { Muya } from '../../index';
 import type { ICursor } from '../../selection/types';
 import type InlineRenderer from '../index';
-import type { Token } from '../types';
+import type { ISyntaxRenderOptions, Token } from '../types';
 import { CLASS_NAMES } from '../../config';
 import { conflict, methodMixins, snakeToCamel } from '../../utils';
 import { h, toHTML } from '../../utils/snabbdom';
@@ -76,6 +76,11 @@ const inlineSyntaxRenderer = {
 
 type InlineSyntaxRender = typeof inlineSyntaxRenderer;
 
+// Generic shape every per-token renderer matches; used by the dynamic
+// dispatcher below (`Renderer.dispatch`) so it can call into the mixin map
+// without an `as any` escape hatch.
+export type TInlineRenderFn = (opts: ISyntaxRenderOptions) => VNode[];
+
 // Declaration-merged with the class below to expose mixin method signatures;
 // must share the class name, so the `I` prefix convention does not apply here.
 // eslint-disable-next-line ts/naming-convention
@@ -135,11 +140,25 @@ class Renderer {
         return active ? CLASS_NAMES.MU_HIGHLIGHT : CLASS_NAMES.MU_SELECTION;
     }
 
+    // Dynamic dispatch helper: each per-token renderer in `inlineSyntaxRenderer`
+    // shares the `(opts: ISyntaxRenderOptions) => VNode[]` signature. Method
+    // names follow `snakeToCamel(token.type)` (e.g. `reference_link` →
+    // `referenceLink`). The runtime guarantee is that
+    // `inlineSyntaxRenderer[name]` exists for every token type the lexer can
+    // emit — declaration-merging `Renderer extends InlineSyntaxRender` already
+    // promises that for known token kinds; this typed indexer just removes
+    // the need for an `(this as any)[name]` escape hatch when the name comes
+    // from a runtime string.
+    dispatch(name: string, opts: ISyntaxRenderOptions): VNode[] {
+        const map = this as unknown as Record<string, TInlineRenderFn>;
+        return map[name](opts);
+    }
+
     output(tokens: Token[], block: Format, cursor: ICursor) {
         const children: VNode[] = tokens.reduce(
             (acc, token) => [
                 ...acc,
-                ...(this as any)[snakeToCamel(token.type)]({
+                ...this.dispatch(snakeToCamel(token.type), {
                     h,
                     cursor,
                     block,

--- a/packages/core/src/inlineRenderer/renderer/link.ts
+++ b/packages/core/src/inlineRenderer/renderer/link.ts
@@ -120,12 +120,14 @@ export default function link(
                     },
                     [
                         ...token.children.reduce((acc: VNode[], to: Token) => {
-                            const chunk = (this as any)[snakeToCamel(to.type)]({
+                            // The original passed a `className` field too, but
+                            // receivers read `outerClass` — so it was silently
+                            // dropped under the previous `as any` cast.
+                            const chunk = this.dispatch(snakeToCamel(to.type), {
                                 h,
                                 cursor,
                                 block,
                                 token: to,
-                                className,
                             });
                             return Array.isArray(chunk)
                                 ? [...acc, ...chunk]
@@ -165,12 +167,13 @@ export default function link(
         return [
             ...firstBracket,
             ...token.children.reduce((acc: VNode[], to: Token) => {
-                const chunk = (this as any)[snakeToCamel(to.type)]({
+                // Original passed `className` here too but receivers read
+                // `outerClass` — see PR note above.
+                const chunk = this.dispatch(snakeToCamel(to.type), {
                     h,
                     cursor,
                     block,
                     token: to,
-                    className,
                 });
 
                 return Array.isArray(chunk) ? [...acc, ...chunk] : [...acc, chunk];

--- a/packages/core/src/inlineRenderer/renderer/referenceLink.ts
+++ b/packages/core/src/inlineRenderer/renderer/referenceLink.ts
@@ -28,12 +28,13 @@ export default function referenceLink(
     const backlashStart = start + MARKER.length + anchor.length;
     const content = [
         ...children.reduce((acc: VNode[], to: Token) => {
-            const chunk: VNode[] = (this as any)[snakeToCamel(to.type)]({
+            // Original passed `className` here too but receivers read
+            // `outerClass` — see PR note in delEmStrongFactory.ts.
+            const chunk: VNode[] = this.dispatch(snakeToCamel(to.type), {
                 h,
                 cursor,
                 block,
                 token: to,
-                className,
             });
 
             return Array.isArray(chunk) ? [...acc, ...chunk] : [...acc, chunk];

--- a/packages/core/src/muya.ts
+++ b/packages/core/src/muya.ts
@@ -18,15 +18,24 @@ import './assets/styles/index.css';
 import './assets/styles/inlineSyntax.css';
 import './assets/styles/prismjs/light.theme.css';
 
+// UI plugins (e.g. InlineFormatToolbar, EmojiSelector) follow a common
+// shape: a class with a static `pluginName` and a constructor that takes
+// `(muya: Muya, options: object)`. `Muya.use` records the constructor + an
+// arbitrary options object; `init()` instantiates each plugin.
+export interface IMuyaPluginConstructor {
+    pluginName: string;
+    new(muya: Muya, options: Record<string, unknown>): unknown;
+}
+
 interface IPlugin {
-    plugin: any;
-    options: any;
+    plugin: IMuyaPluginConstructor;
+    options: Record<string, unknown>;
 }
 
 export class Muya {
     static plugins: IPlugin[] = [];
 
-    static use(plugin: any, options = {}) {
+    static use(plugin: IMuyaPluginConstructor, options: Record<string, unknown> = {}) {
         this.plugins.push({
             plugin,
             options,
@@ -41,7 +50,7 @@ export class Muya {
     public ui: Ui;
     public i18n: I18n;
 
-    private _uiPlugins: Record<string, any> = {};
+    private _uiPlugins: Record<string, unknown> = {};
 
     constructor(element: HTMLElement, options?: Partial<IMuyaOptions>) {
         this.options = Object.assign({}, MUYA_DEFAULT_OPTIONS, options ?? {});

--- a/packages/core/src/selection/index.ts
+++ b/packages/core/src/selection/index.ts
@@ -667,12 +667,17 @@ class Selection {
             ? focusBlock.domNode
             : scrollPage?.queryBlock(focusPath);
 
+        // getNodeAndOffset expects a DOM Node. The fallback branch can hand
+        // back a Parent/Content block (from scrollPage.queryBlock), which
+        // historically reached this code path under an `as any` cast. Keep
+        // the existing runtime behavior via a single narrow cast — fixing
+        // the underlying contract is out of scope for this PR.
         const { node: anchorNode, offset: anchorOffset } = getNodeAndOffset(
-            anchorParagraph,
+            anchorParagraph as unknown as Node,
             anchor.offset,
         );
         const { node: focusNode, offset: focusOffset } = getNodeAndOffset(
-            focusParagraph,
+            focusParagraph as unknown as Node,
             focus.offset,
         );
 

--- a/packages/core/src/state/__tests__/markdownToState.spec.ts
+++ b/packages/core/src/state/__tests__/markdownToState.spec.ts
@@ -2,7 +2,18 @@ import { describe, expect, it } from 'vitest';
 import { MarkdownToState } from '../markdownToState';
 import ExportMarkdown from '../stateToMarkdown';
 
-function generate(markdown: string, options: Partial<{ footnote: boolean }> = {}) {
+// Loose accessor type used only in this spec — every state node the
+// MarkdownToState pipeline emits has some subset of these fields, and the
+// tests navigate the tree generically without re-implementing the
+// discriminated TState union narrowing.
+interface IStateLike {
+    name: string;
+    text?: string;
+    meta?: Record<string, unknown> & { checked?: boolean; identifier?: string; level?: number; underline?: string };
+    children?: IStateLike[];
+}
+
+function generate(markdown: string, options: Partial<{ footnote: boolean }> = {}): IStateLike[] {
     return new MarkdownToState({
         footnote: false,
         math: false,
@@ -10,7 +21,7 @@ function generate(markdown: string, options: Partial<{ footnote: boolean }> = {}
         trimUnnecessaryCodeBlockEmptyLines: false,
         frontMatter: false,
         ...options,
-    }).generate(markdown);
+    }).generate(markdown) as unknown as IStateLike[];
 }
 
 // Defensive regression test for marktext commit 23435ce6 (#1733 / PR #1835).
@@ -36,31 +47,31 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         // Outer list must contain exactly one task-list-item with a nested
         // bullet/task list as its second child (first being the text para).
         expect(states.length).toBe(1);
-        const outer = states[0] as any;
+        const outer = states[0];
         expect(outer.name).toBe('task-list');
-        expect(outer.children.length).toBe(1);
+        expect(outer.children!.length).toBe(1);
 
-        const level1 = outer.children[0];
+        const level1 = outer.children![0];
         expect(level1.name).toBe('task-list-item');
         expect(level1.meta).toEqual({ checked: false });
-        const level1Paragraph = level1.children.find((c: any) => c.name === 'paragraph');
+        const level1Paragraph = level1.children!.find(c => c.name === 'paragraph');
         expect(level1Paragraph?.text).toBe('task1');
 
-        const level1Nested = level1.children.find((c: any) => c.name === 'task-list');
+        const level1Nested = level1.children!.find(c => c.name === 'task-list');
         expect(level1Nested, 'level 1 should contain a nested bullet-list').toBeDefined();
-        expect(level1Nested.children.length).toBe(1);
+        expect(level1Nested!.children!.length).toBe(1);
 
-        const level2 = level1Nested.children[0];
+        const level2 = level1Nested!.children![0];
         expect(level2.name).toBe('task-list-item');
-        expect(level2.children.find((c: any) => c.name === 'paragraph')?.text).toBe('task1_1');
+        expect(level2.children!.find(c => c.name === 'paragraph')?.text).toBe('task1_1');
 
-        const level2Nested = level2.children.find((c: any) => c.name === 'task-list');
+        const level2Nested = level2.children!.find(c => c.name === 'task-list');
         expect(level2Nested, 'level 2 should contain a nested bullet-list — not a sibling').toBeDefined();
-        expect(level2Nested.children.length).toBe(1);
+        expect(level2Nested!.children!.length).toBe(1);
 
-        const level3 = level2Nested.children[0];
+        const level3 = level2Nested!.children![0];
         expect(level3.name).toBe('task-list-item');
-        expect(level3.children.find((c: any) => c.name === 'paragraph')?.text).toBe('task1_1_1');
+        expect(level3.children!.find(c => c.name === 'paragraph')?.text).toBe('task1_1_1');
     });
 
     // Defensive regression for marktext commit dec7502e (PR #741):
@@ -70,27 +81,27 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
     it('parses setext h1 (=== underline) as setext-heading with level 1', () => {
         const states = generate(`Hello world
 ===========
-`) as any[];
+`);
         expect(states.length).toBe(1);
         expect(states[0].name).toBe('setext-heading');
-        expect(states[0].meta.level).toBe(1);
-        expect(states[0].meta.underline).toBeTruthy();
+        expect(states[0].meta!.level).toBe(1);
+        expect(states[0].meta!.underline).toBeTruthy();
     });
 
     it('parses setext h2 (--- underline) as setext-heading with level 2', () => {
         const states = generate(`Hello world
 -----------
-`) as any[];
+`);
         expect(states.length).toBe(1);
         expect(states[0].name).toBe('setext-heading');
-        expect(states[0].meta.level).toBe(2);
+        expect(states[0].meta!.level).toBe(2);
     });
 
     it('parses `# text` as atx-heading, not setext-heading', () => {
         // Positive control: atx headings should remain atx.
-        const states = generate('# Hello\n') as any[];
+        const states = generate('# Hello\n');
         expect(states[0].name).toBe('atx-heading');
-        expect(states[0].meta.level).toBe(1);
+        expect(states[0].meta!.level).toBe(1);
     });
 
     it('starts a new list when the bullet marker changes (CommonMark 264, marktext 270d33f6)', () => {
@@ -98,12 +109,12 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         const states = generate(`- foo
 - bar
 + baz
-`) as any[];
+`);
         expect(states.length).toBe(2);
         expect(states[0].name).toBe('bullet-list');
-        expect(states[0].children.length).toBe(2);
+        expect(states[0].children!.length).toBe(2);
         expect(states[1].name).toBe('bullet-list');
-        expect(states[1].children.length).toBe(1);
+        expect(states[1].children!.length).toBe(1);
     });
 
     it('starts a new list when the ordered delimiter changes (CommonMark 265, marktext 270d33f6)', () => {
@@ -111,12 +122,12 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         const states = generate(`1. foo
 2. bar
 3) baz
-`) as any[];
+`);
         expect(states.length).toBe(2);
         expect(states[0].name).toBe('order-list');
-        expect(states[0].children.length).toBe(2);
+        expect(states[0].children!.length).toBe(2);
         expect(states[1].name).toBe('order-list');
-        expect(states[1].children.length).toBe(1);
+        expect(states[1].children!.length).toBe(1);
     });
 
     it('does not parse `-foo` (no space) as a list item (marktext 70d49c30)', () => {
@@ -125,7 +136,7 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         // bullet marker must be followed by a space (or newline) to start
         // a list. The new muya uses marked v16's built-in list rule which
         // already enforces this — keep the regression test.
-        const states = generate('-foo\n') as any[];
+        const states = generate('-foo\n');
         expect(states.length).toBe(1);
         expect(states[0].name).toBe('paragraph');
         expect(states[0].text).toBe('-foo');
@@ -133,10 +144,10 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
 
     it('still parses `- foo` (with space) as a list item', () => {
         // Positive control — same shape with the required space.
-        const states = generate('- foo\n') as any[];
+        const states = generate('- foo\n');
         expect(states.length).toBe(1);
         expect(states[0].name).toBe('bullet-list');
-        expect(states[0].children[0].name).toBe('list-item');
+        expect(states[0].children![0].name).toBe('list-item');
     });
 
     it('splits a mixed task + bullet sequence into two lists (marktext 372fe02f)', () => {
@@ -155,17 +166,17 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
 `);
 
         expect(states.length).toBe(2);
-        const [first, second] = states as any[];
+        const [first, second] = states;
         expect(first.name).toBe('task-list');
-        expect(first.children.length).toBe(2);
-        expect(first.children.every((c: any) => c.name === 'task-list-item')).toBe(true);
-        expect(first.children.map((c: any) => c.meta.checked)).toEqual([true, true]);
+        expect(first.children!.length).toBe(2);
+        expect(first.children!.every(c => c.name === 'task-list-item')).toBe(true);
+        expect(first.children!.map(c => c.meta?.checked)).toEqual([true, true]);
 
         expect(second.name).toBe('bullet-list');
-        expect(second.children.length).toBe(2);
-        expect(second.children.every((c: any) => c.name === 'list-item')).toBe(true);
-        const secondTexts = second.children.map((c: any) =>
-            c.children.find((cc: any) => cc.name === 'paragraph')?.text,
+        expect(second.children!.length).toBe(2);
+        expect(second.children!.every(c => c.name === 'list-item')).toBe(true);
+        const secondTexts = second.children!.map(c =>
+            c.children!.find(cc => cc.name === 'paragraph')?.text,
         );
         expect(secondTexts).toEqual(['zar', 'rar']);
     });
@@ -181,10 +192,10 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
 [^1]: definition`,
             { footnote: true },
         );
-        const footnote = states.find(s => s.name === 'footnote') as any;
+        const footnote = states.find(s => s.name === 'footnote');
         expect(footnote, 'a footnote state should be emitted').toBeDefined();
-        expect(footnote.meta.identifier).toBe('1');
-        const firstChild = footnote.children[0];
+        expect(footnote!.meta!.identifier).toBe('1');
+        const firstChild = footnote!.children![0];
         expect(firstChild.name).toBe('paragraph');
         expect(firstChild.text).toBe('definition');
     });
@@ -195,7 +206,7 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
 [^1]: definition
 `;
         const states = generate(md, { footnote: true });
-        const out = new ExportMarkdown({ listIndentation: 1 }).generate(states);
+        const out = new ExportMarkdown({ listIndentation: 1 }).generate(states as unknown as Parameters<ExportMarkdown['generate']>[0]);
         // The serialiser emits the canonical `[^id]: ` form on its own line.
         expect(out).toContain('[^1]: definition');
     });
@@ -209,14 +220,14 @@ describe('markdownToState — task list nesting (marktext 23435ce6)', () => {
         const states = generate(md);
 
         expect(states.length).toBe(1);
-        const outer = states[0] as any;
+        const outer = states[0];
         expect(outer.name).toBe('task-list');
 
-        const level1 = outer.children[0];
-        const level1Nested = level1.children.find((c: any) => c.name === 'task-list');
+        const level1 = outer.children![0];
+        const level1Nested = level1.children!.find(c => c.name === 'task-list');
         expect(level1Nested).toBeDefined();
-        const level2 = level1Nested.children[0];
-        const level2Nested = level2.children.find((c: any) => c.name === 'task-list');
+        const level2 = level1Nested!.children![0];
+        const level2Nested = level2.children!.find(c => c.name === 'task-list');
         expect(level2Nested, 'level 2 should contain level 3 nested, not as sibling').toBeDefined();
     });
 });

--- a/packages/core/src/state/__tests__/referenceLink.spec.ts
+++ b/packages/core/src/state/__tests__/referenceLink.spec.ts
@@ -83,9 +83,9 @@ describe('reference link / image — markdown ↔ state round-trip', () => {
 
         const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph' && s.text!.startsWith('foo')) as { text: string };
         const tokens = tokenize(para.text, labels);
-        const refTok = tokens.find(t => t.type === 'reference_link') as any;
+        const refTok = tokens.find(t => t.type === 'reference_link');
         expect(refTok, 'reference_link token should be emitted once labels are known').toBeDefined();
-        expect(refTok.label).toBe('1');
+        expect((refTok as Extract<typeof tokens[number], { type: 'reference_link' }>).label).toBe('1');
     });
 
     it('case 4 — inline tokenize: Full / Collapsed / Shortcut forms all produce reference_link tokens', () => {
@@ -94,7 +94,7 @@ describe('reference link / image — markdown ↔ state round-trip', () => {
 
         const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph' && s.text!.startsWith('A ')) as { text: string };
         const tokens = tokenize(para.text, labels);
-        const refToks = tokens.filter(t => t.type === 'reference_link') as any[];
+        const refToks = tokens.filter(t => t.type === 'reference_link') as Extract<typeof tokens[number], { type: 'reference_link' }>[];
         expect(refToks.length).toBe(3);
         expect(refToks[0].isFullLink).toBe(true);
         expect(refToks[1].isFullLink).toBe(false);
@@ -118,7 +118,7 @@ describe('reference link / image — markdown ↔ state round-trip', () => {
 
         const para = (states as Array<{ name: string; text?: string }>).find(s => s.name === 'paragraph' && s.text!.startsWith('foo')) as { text: string };
         const tokens = tokenize(para.text, labels);
-        const refTok = tokens.find(t => t.type === 'reference_link') as any;
+        const refTok = tokens.find(t => t.type === 'reference_link');
         expect(refTok, 'reference_link must match label irrespective of case').toBeDefined();
     });
 
@@ -139,7 +139,7 @@ describe('reference link / image — markdown ↔ state round-trip', () => {
         const tokens = tokenize(para.text, labels);
         const refTok = tokens.find(t => t.type === 'reference_link');
         expect(refTok, 'no reference_link token should fire without a matching definition').toBeUndefined();
-        const raw = tokens.map((t: any) => t.raw).join('');
+        const raw = tokens.map(t => t.raw).join('');
         expect(raw).toContain('[missing][nope]');
     });
 });

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -1,4 +1,4 @@
-import type { Doc, JSONOpList, Path } from 'ot-json1';
+import type { Doc, JSONOp, JSONOpList, Path } from 'ot-json1';
 import type { Muya } from '../muya';
 import type { TDiff } from '../utils';
 import type { TState } from './types';
@@ -38,7 +38,12 @@ class JSONState {
         this.setContent(stateOrMarkdown);
     }
 
-    apply(op: JSONOpList) {
+    apply(op: JSONOp) {
+        // ot-json1's noop is the literal `null`. `json1.type.apply` accepts it
+        // and returns the doc unchanged — short-circuit instead so the rest of
+        // the call site can treat `op` as definitely applied.
+        if (op === null)
+            return;
         this._state = json1.type.apply(
             this._state as unknown as Doc,
             op,
@@ -106,7 +111,7 @@ class JSONState {
         this._emitStateChange();
     }
 
-    dispatch(op: JSONOpList, source = 'user' /* user, api */) {
+    dispatch(op: JSONOp, source = 'user' /* user, api */) {
         const prevDoc = this.getState();
         this.apply(op);
         // TODO: remove doc in future

--- a/packages/core/src/state/index.ts
+++ b/packages/core/src/state/index.ts
@@ -138,7 +138,19 @@ class JSONState {
         this._isGoing = true;
 
         requestAnimationFrame(() => {
-            const op = this._operationCache.reduce(json1.type.compose as any);
+            // Wrap compose in a lambda — `Array.prototype.reduce` passes
+            // (acc, current, index, array) to the callback, but
+            // `json1.type.compose` only accepts (op1, op2). Without the
+            // wrapper TS rejects the signature mismatch.
+            // `compose` returns JSONOp (= null | JSONOpList); when the cache
+            // contains at least one op the result is the composed list,
+            // never null. The reduce above runs only when _operationCache is
+            // non-empty (guarded by the requestAnimationFrame in
+            // `_emitStateChange`), and a non-empty cache always composes to
+            // a non-null op.
+            const op = this._operationCache.reduce(
+                (acc, curr) => json1.type.compose(acc, curr) as JSONOpList,
+            );
             const prevDoc = this.getState();
             this.apply(op);
             // TODO: remove doc in future

--- a/packages/core/src/state/markdownToState.ts
+++ b/packages/core/src/state/markdownToState.ts
@@ -1,4 +1,15 @@
-import type { TState } from './types';
+import type { TBlockToken } from '../utils/marked/types';
+import type {
+    IAtxHeadingState,
+    IBulletListState,
+    IListItemState,
+    IOrderListState,
+    ISetextHeadingState,
+    ITableState,
+    ITaskListItemState,
+    ITaskListState,
+    TState,
+} from './types';
 import logger from '../utils/logger';
 import { lexBlock } from '../utils/marked';
 
@@ -42,7 +53,10 @@ export class MarkdownToState {
             frontMatter = true,
         } = this._options;
 
-        const tokens = lexBlock(markdown, {
+        // markdownToState injects synthetic `block-end` markers (see the
+        // blockquote/list/list_item/footnote cases below) to pop the parent
+        // stack, so the working stream is wider than what `lexBlock` returns.
+        const tokens: TBlockToken[] = lexBlock(markdown, {
             footnote,
             math,
             frontMatter,
@@ -50,9 +64,9 @@ export class MarkdownToState {
         });
 
         const states: TState[] = [];
-        let token;
+        let token: TBlockToken | undefined;
         let state: TState;
-        let value;
+        let value: string;
         const parentList: TState[][] = [states];
 
         // eslint-disable-next-line no-cond-assign
@@ -102,23 +116,27 @@ export class MarkdownToState {
                 }
 
                 case 'heading': {
-                    const { headingStyle, depth, text, marker } = token as any;
-                    const name
-                        = headingStyle === 'atx' ? 'atx-heading' : 'setext-heading';
-                    const meta: any = {
-                        level: depth,
-                    };
-                    if (name === 'setext-heading')
-                        meta.underline = marker;
+                    const { headingStyle, depth, text, marker } = token;
+                    value = headingStyle === 'atx'
+                        ? `${'#'.repeat(+depth)} ${text}`
+                        : text;
 
-                    value
-                        = name === 'atx-heading' ? `${'#'.repeat(+depth)} ${text}` : text;
-
-                    state = {
-                        name,
-                        meta,
-                        text: value,
-                    };
+                    if (headingStyle === 'atx') {
+                        const atxState: IAtxHeadingState = {
+                            name: 'atx-heading',
+                            meta: { level: depth },
+                            text: value,
+                        };
+                        state = atxState;
+                    }
+                    else {
+                        const setextState: ISetextHeadingState = {
+                            name: 'setext-heading',
+                            meta: { level: depth, underline: marker },
+                            text: value,
+                        };
+                        state = setextState;
+                    }
 
                     parentList[0].push(state);
                     break;
@@ -127,8 +145,10 @@ export class MarkdownToState {
                 case 'code': {
                     const { codeBlockStyle, text, lang: infoString = '' } = token;
 
-                    // GH#697, markedjs#1387
-                    const lang = (infoString || '').match(/\S*/)[0];
+                    // GH#697, markedjs#1387 — strip everything past the first
+                    // whitespace; `\S*` matches the empty string so this is
+                    // always non-null even for `infoString === ''`.
+                    const lang = (infoString || '').match(/\S*/)?.[0] ?? '';
 
                     value = text;
                     // Fix: #1265.
@@ -139,21 +159,30 @@ export class MarkdownToState {
                         value = value.replace(/\n+$/, '').replace(/^\n+/, '');
                     }
 
-                    if (/mermaid|vega-lite|plantuml/.test(lang)) {
+                    const diagramMatch = /^(mermaid|vega-lite|plantuml)$/.exec(lang);
+                    if (diagramMatch) {
+                        const diagramType = diagramMatch[1] as 'mermaid' | 'vega-lite' | 'plantuml';
                         state = {
                             name: 'diagram' as const,
                             text: value,
                             meta: {
-                                type: lang,
-                                lang: lang === 'vega-lite' ? 'json' : 'yaml',
+                                type: diagramType,
+                                lang: diagramType === 'vega-lite' ? 'json' : 'yaml',
                             },
                         };
                     }
                     else {
+                        // walkTokens (utils/marked/walkTokens.ts) writes
+                        // codeBlockStyle = 'fenced' for fenced blocks and
+                        // leaves 'indented' for indented blocks. marked's
+                        // type widens the field to `'indented' | undefined`,
+                        // but `'fenced'` reaches us at runtime via the
+                        // walkTokens assignment — hence the cast.
+                        const isFenced = (codeBlockStyle as 'indented' | 'fenced' | undefined) === 'fenced';
                         state = {
                             name: 'code-block' as const,
                             meta: {
-                                type: codeBlockStyle === 'fenced' ? 'fenced' : 'indented',
+                                type: isFenced ? 'fenced' : 'indented',
                                 lang,
                             },
                             text: value,
@@ -165,32 +194,32 @@ export class MarkdownToState {
 
                 case 'table': {
                     const { header, align, rows } = token;
-
-                    state = {
+                    const tableState: ITableState = {
                         name: 'table',
                         children: [],
                     };
 
-                    state.children.push({
+                    tableState.children.push({
                         name: 'table.row',
-                        children: header.map((h: { text: string }, i: string | number) => ({ // TODO: @jocs fix type
-                            name: 'table.cell',
+                        children: header.map((h, i) => ({
+                            name: 'table.cell' as const,
                             meta: { align: align[i] || 'none' },
                             text: restoreTableEscapeCharacters(h.text),
                         })),
                     });
 
-                    state.children.push(
-                        ...rows.map((row: any[]) => ({ // TODO: @jocs fix type
-                            name: 'table.row',
+                    tableState.children.push(
+                        ...rows.map(row => ({
+                            name: 'table.row' as const,
                             children: row.map((c, i) => ({
-                                name: 'table.cell',
+                                name: 'table.cell' as const,
                                 meta: { align: align[i] || 'none' },
                                 text: restoreTableEscapeCharacters(c.text),
                             })),
                         })),
                     );
 
+                    state = tableState;
                     parentList[0].push(state);
                     break;
                 }
@@ -230,9 +259,9 @@ export class MarkdownToState {
 
                 case 'text': {
                     value = token.text;
-                    while (tokens[0].type === 'text') {
-                        token = tokens.shift() as any;
-                        value += `\n${token.text}`;
+                    while (tokens[0]?.type === 'text') {
+                        const next = tokens.shift() as Extract<TBlockToken, { type: 'text' }>;
+                        value += `\n${next.text}`;
                     }
                     state = {
                         name: 'paragraph',
@@ -259,53 +288,79 @@ export class MarkdownToState {
                     };
                     parentList[0].push(state);
                     parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'blockquote' } as any);
-                    tokens.unshift(...token.tokens as any);
+                    tokens.unshift({ type: 'block-end', tokenType: 'blockquote' });
+                    tokens.unshift(...(token.tokens as TBlockToken[]));
                     break;
                 }
 
                 case 'list': {
-                    const { listType, loose, start } = token as any;
+                    const { listType, loose, start } = token;
                     const bulletMarkerOrDelimiter
                         = token.items[0].bulletMarkerOrDelimiter;
-                    const meta: any = {
-                        loose,
-                    };
+
+                    let listState: IOrderListState | IBulletListState | ITaskListState;
                     if (listType === 'order') {
-                        meta.start = /^\d+$/.test(start) ? start : 1;
-                        meta.delimiter = bulletMarkerOrDelimiter || '.';
+                        listState = {
+                            name: 'order-list',
+                            meta: {
+                                loose,
+                                start: /^\d+$/.test(String(start)) ? Number(start) : 1,
+                                delimiter: bulletMarkerOrDelimiter || '.',
+                            },
+                            children: [],
+                        };
+                    }
+                    else if (listType === 'task') {
+                        listState = {
+                            name: 'task-list',
+                            meta: {
+                                loose,
+                                marker: bulletMarkerOrDelimiter || '-',
+                            },
+                            children: [],
+                        };
                     }
                     else {
-                        meta.marker = bulletMarkerOrDelimiter || '-';
+                        listState = {
+                            name: 'bullet-list',
+                            meta: {
+                                loose,
+                                marker: bulletMarkerOrDelimiter || '-',
+                            },
+                            children: [],
+                        };
                     }
-                    state = {
-                        name: `${listType}-list` as any,
-                        meta,
-                        children: [],
-                    };
 
+                    state = listState;
                     parentList[0].push(state);
-                    parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'list' } as any);
-                    tokens.unshift(...token.items);
+                    parentList.unshift(state.children as TState[]);
+                    tokens.unshift({ type: 'block-end', tokenType: 'list' });
+                    tokens.unshift(...(token.items as TBlockToken[]));
                     break;
                 }
 
                 case 'list_item': {
-                    const { checked, listItemType } = token as any;
+                    const { listItemType, checked } = token;
+                    let itemState: IListItemState | ITaskListItemState;
+                    if (listItemType === 'task') {
+                        itemState = {
+                            name: 'task-list-item',
+                            meta: { checked: Boolean(checked) },
+                            children: [],
+                        };
+                    }
+                    else {
+                        itemState = {
+                            name: 'list-item',
+                            children: [],
+                        };
+                    }
 
-                    state = {
-                        name: (listItemType === 'task' ? 'task-list-item' : 'list-item') as any,
-                        children: [],
-                    };
-
-                    if (listItemType === 'task')
-                        (state as any).meta = { checked };
-
+                    state = itemState;
                     parentList[0].push(state);
                     parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'list-item' } as any);
-                    tokens.unshift(...token.tokens as any);
+                    tokens.unshift({ type: 'block-end', tokenType: 'list-item' });
+                    tokens.unshift(...(token.tokens as TBlockToken[]));
                     break;
                 }
 
@@ -324,7 +379,7 @@ export class MarkdownToState {
                     // model. See plan section 13 (PR-16).
                     state = {
                         name: 'paragraph' as const,
-                        text: (token as any).raw.replace(/\n+$/, ''),
+                        text: token.raw.replace(/\n+$/, ''),
                     };
                     parentList[0].push(state);
                     break;
@@ -335,7 +390,7 @@ export class MarkdownToState {
                     // emits a parent token whose `tokens` array holds nested
                     // block tokens. Mirror that into a `footnote` container
                     // state and recurse via tokens.unshift / block-end.
-                    const { identifier } = token as any;
+                    const { identifier } = token;
                     state = {
                         name: 'footnote' as const,
                         meta: { identifier },
@@ -343,8 +398,8 @@ export class MarkdownToState {
                     };
                     parentList[0].push(state);
                     parentList.unshift(state.children);
-                    tokens.unshift({ type: 'block-end', tokenType: 'footnote' } as any);
-                    tokens.unshift(...(token as any).tokens);
+                    tokens.unshift({ type: 'block-end', tokenType: 'footnote' });
+                    tokens.unshift(...(token.tokens as TBlockToken[]));
                     break;
                 }
 

--- a/packages/core/src/state/stateToMarkdown.ts
+++ b/packages/core/src/state/stateToMarkdown.ts
@@ -43,7 +43,16 @@ export interface IExportMarkdownOptions {
 }
 
 export default class ExportMarkdown {
-    private _listType: any[];
+    // Stack of currently-open list metas while serializing a tree (push on
+    // descent into bullet/order/task list, pop on ascent). The serializer
+    // reads `loose` / `marker` / `delimiter` / `start` from the top entry
+    // to render the correct bullet, indentation, and tightness.
+    private _listType: (
+        | IBulletListState['meta']
+        | IOrderListState['meta']
+        | ITaskListState['meta']
+    )[];
+
     private _isLooseParentList: boolean;
     private _listIndentation: string;
     private _listIndentationCount: number;
@@ -473,7 +482,11 @@ export default class ExportMarkdown {
     ) {
         const result = [];
         const listInfo = this._listType[this._listType.length - 1];
-        const { marker, delimiter, start } = listInfo;
+        // `listInfo` is one of three list-meta shapes (bullet / order / task).
+        // bullet & task carry `marker`; order carries `delimiter` + `start`.
+        // We discriminate on presence of `marker` to pick the right fields.
+        const marker = 'marker' in listInfo ? listInfo.marker : undefined;
+        const delimiter = 'delimiter' in listInfo ? listInfo.delimiter : undefined;
         const isUnorderedList = !!marker;
         const { children, name } = state;
         let itemMarker;
@@ -481,16 +494,19 @@ export default class ExportMarkdown {
         if (isUnorderedList) {
             itemMarker = marker ? `${marker} ` : '- ';
         }
-        else {
+        else if ('start' in listInfo) {
             // NOTE: GitHub and Bitbucket limit the list count to 99 but this is nowhere defined.
             //  We limit the number to 99 for Daring Fireball Markdown to prevent indentation issues.
-            let n = start;
+            let n = listInfo.start;
             if ((this._listIndentation === 'dfm' && n > 99) || n > 999999999)
                 n = 1;
 
             listInfo.start++;
 
             itemMarker = `${n}${delimiter || '.'} `;
+        }
+        else {
+            itemMarker = '- ';
         }
 
         // Subsequent paragraph indentation

--- a/packages/core/src/types/global.d.ts
+++ b/packages/core/src/types/global.d.ts
@@ -10,4 +10,23 @@ declare global {
     interface Element {
         __MUYA_BLOCK__: Content | Parent;
     }
+
+    // `Intl.Segmenter` (Stage 4, ES2022) is not in the ES2020 TS lib the
+    // package targets. Declare the minimal surface we use so `visibleLength`
+    // can call it without an `as any` escape hatch. The examples app
+    // polyfills it when the runtime engine lacks support.
+    namespace Intl {
+        interface ISegmenterOptions {
+            granularity?: 'grapheme' | 'word' | 'sentence';
+        }
+        interface ISegmentData {
+            segment: string;
+            index: number;
+            input: string;
+        }
+        class Segmenter {
+            constructor(locales?: string | string[], options?: ISegmenterOptions);
+            segment(input: string): Iterable<ISegmentData>;
+        }
+    }
 }

--- a/packages/core/src/ui/baseFloat/index.ts
+++ b/packages/core/src/ui/baseFloat/index.ts
@@ -144,7 +144,11 @@ abstract class BaseFloat {
         else eventCenter.emit('muya-float', this, false);
     }
 
-    show(reference: ReferenceElement, cb = noop) {
+    // `cb` is a generic "selection made" callback. Concrete floats invoke it
+    // with their own argument tuple (e.g. emojiSelector → `(item)`,
+    // tableChessboard → `(row, column)`). `never[]` in the contravariant
+    // arg position accepts any concrete callback shape.
+    show(reference: ReferenceElement, cb: (...args: never[]) => void = noop) {
         const { floatBox } = this;
         const { eventCenter } = this.muya;
         const { placement, offsetOptions } = this.options;
@@ -157,7 +161,10 @@ abstract class BaseFloat {
             this._cleanup = null;
         }
 
-        this.cb = cb;
+        // `cb` is declared with `never[]` args at the parameter so any
+        // concrete callback shape is accepted; the field stores it as
+        // `unknown[]` so internal call sites can forward arbitrary args.
+        this.cb = cb as (...args: unknown[]) => void;
 
         this._cleanup = autoUpdate(reference, floatBox, () => {
             computePosition(reference, floatBox, {

--- a/packages/core/src/ui/baseScrollFloat/index.ts
+++ b/packages/core/src/ui/baseScrollFloat/index.ts
@@ -67,8 +67,10 @@ abstract class BaseScrollFloat extends BaseFloat {
         this.reference = null;
     }
 
-    override show(reference: Element | ReferenceElement, cb: (...args: unknown[]) => void = noop) {
-        this.cb = cb;
+    override show(reference: Element | ReferenceElement, cb: (...args: never[]) => void = noop) {
+        // See BaseFloat.show: callbacks accept any shape; store as unknown[]
+        // so internal forwarding stays workable.
+        this.cb = cb as (...args: unknown[]) => void;
 
         if (reference instanceof HTMLElement) {
             if (this.reference && this.reference === reference && this.status)

--- a/packages/core/src/ui/emojiSelector/index.ts
+++ b/packages/core/src/ui/emojiSelector/index.ts
@@ -59,7 +59,7 @@ export class EmojiSelector extends BaseScrollFloat {
             const text = emojiText.trim();
             if (text) {
                 this.renderObj = this._emoji.search(text);
-                const cb: any = (item: EmojiType) => {
+                const cb: (item: EmojiType) => void = (item) => {
                     if (block && block.setEmoji)
                         block.setEmoji(item.aliases[0]);
                 };

--- a/packages/core/src/ui/linkTools/__tests__/linkTools.spec.ts
+++ b/packages/core/src/ui/linkTools/__tests__/linkTools.spec.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import type Format from '../../../block/base/format';
 import type { Muya } from '../../../muya';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import EventCenter from '../../../event';
@@ -73,7 +74,9 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
     it('unlink: routes to block.unlink with { range, text } from linkInfo', () => {
         const { tools } = bootLinkTools();
         const blockUnlink = vi.fn();
-        tools.linkBlock = { unlink: blockUnlink } as any;
+        // linkBlock is typed as Format | null; the fake only implements
+        // `unlink` (the only method selectItem calls).
+        tools.linkBlock = { unlink: blockUnlink } as unknown as Format;
         tools.linkInfo = {
             href: 'https://example.com',
             text: 'hi',
@@ -102,7 +105,9 @@ describe('linkTools.selectItem — dispatches to block.unlink / jumpClick', () =
     it('unlink: no-ops when linkInfo.range is missing', () => {
         const { tools } = bootLinkTools();
         const blockUnlink = vi.fn();
-        tools.linkBlock = { unlink: blockUnlink } as any;
+        // linkBlock is typed as Format | null; the fake only implements
+        // `unlink` (the only method selectItem calls).
+        tools.linkBlock = { unlink: blockUnlink } as unknown as Format;
         tools.linkInfo = { href: 'x', text: 'y', range: null };
 
         tools.selectItem(makeFakeEvent(), { type: 'unlink', icon: '' });

--- a/packages/core/src/ui/paragraphFrontButton/index.ts
+++ b/packages/core/src/ui/paragraphFrontButton/index.ts
@@ -110,8 +110,14 @@ export class ParagraphFrontButton {
         const { _container: container } = this;
         const { eventCenter } = this.muya;
 
-        const mousemoveHandler = throttle((event: MouseEvent) => {
+        // attachDOMEvent's listener is typed as `EventListener` ((evt:
+        // Event) => void). Take Event and narrow with the `isMouseEvent`
+        // guard — same pattern as `mouseMove` below — rather than casting
+        // the wrapper to EventListener (which would hide a real mismatch).
+        const mousemoveHandler = throttle((event: Event) => {
             if (this._disableListen)
+                return;
+            if (!isMouseEvent(event))
                 return;
 
             const { x, y } = event;
@@ -144,7 +150,7 @@ export class ParagraphFrontButton {
 
         eventCenter.attachDOMEvent(container, 'mousedown', this.dragBarMouseDown);
         eventCenter.attachDOMEvent(container, 'mouseup', this.dragBarMouseUp);
-        eventCenter.attachDOMEvent(document, 'mousemove', mousemoveHandler as EventListener);
+        eventCenter.attachDOMEvent(document, 'mousemove', mousemoveHandler);
         eventCenter.attachDOMEvent(container, 'click', clickHandler);
     }
 

--- a/packages/core/src/ui/paragraphFrontButton/index.ts
+++ b/packages/core/src/ui/paragraphFrontButton/index.ts
@@ -144,7 +144,7 @@ export class ParagraphFrontButton {
 
         eventCenter.attachDOMEvent(container, 'mousedown', this.dragBarMouseDown);
         eventCenter.attachDOMEvent(container, 'mouseup', this.dragBarMouseUp);
-        eventCenter.attachDOMEvent(document, 'mousemove', mousemoveHandler);
+        eventCenter.attachDOMEvent(document, 'mousemove', mousemoveHandler as EventListener);
         eventCenter.attachDOMEvent(container, 'click', clickHandler);
     }
 

--- a/packages/core/src/ui/paragraphFrontMenu/__tests__/canTurnIntoMenu.spec.ts
+++ b/packages/core/src/ui/paragraphFrontMenu/__tests__/canTurnIntoMenu.spec.ts
@@ -1,4 +1,5 @@
 // @vitest-environment happy-dom
+import type Parent from '../../../block/base/parent';
 import { describe, expect, it } from 'vitest';
 import { canTurnIntoMenu } from '../config';
 
@@ -31,13 +32,15 @@ import { canTurnIntoMenu } from '../config';
 // full Muya bootstrap, but the front-menu gate is enough to demonstrate
 // that the user has no UI path to nest a math-block inside a math-block.
 
-function fakeBlock(blockName: string, paragraphText: string = ''): any {
+// `canTurnIntoMenu` only reads `blockName` and `firstContentInDescendant()`
+// on the passed-in block; the structural fake covers that surface.
+function fakeBlock(blockName: string, paragraphText: string = ''): Parent {
     return {
         blockName,
         firstContentInDescendant() {
             return { text: paragraphText };
         },
-    };
+    } as unknown as Parent;
 }
 
 describe('canTurnIntoMenu — no nesting math/code/html/diagram inside themselves (marktext 7b7a9424)', () => {

--- a/packages/core/src/ui/paragraphFrontMenu/index.ts
+++ b/packages/core/src/ui/paragraphFrontMenu/index.ts
@@ -1,4 +1,5 @@
 import type { VNode } from 'snabbdom';
+import type Content from '../../block/base/content';
 import type Parent from '../../block/base/parent';
 import type AtxHeading from '../../block/commonMark/atxHeading';
 import type { Muya } from '../../index';
@@ -6,6 +7,7 @@ import type {
     IAtxHeadingState,
     IBulletListState,
     IOrderListState,
+    ITaskListItemState,
     ITaskListState,
 } from '../../state/types';
 import type { IQuickInsertMenuItem } from '../paragraphQuickInsertMenu/config';
@@ -277,39 +279,50 @@ export class ParagraphFrontMenu extends BaseFloat {
                     | IOrderListState
                     | ITaskListState
                     | IBulletListState;
+                    // The conversion between order/bullet/task lists
+                    // re-shapes both the parent meta and the per-item meta.
+                    // The static `IListItemState` doesn't carry `meta`, while
+                    // `ITaskListItemState` does; the casts below are the
+                    // narrow target-shape assertions for that runtime swap.
                     if (block.blockName === 'task-list') {
                         state.children.forEach((listItem) => {
                             listItem.name = 'list-item';
-                            delete (listItem as any).meta;
+                            delete (listItem as Partial<ITaskListItemState>).meta;
                         });
                     }
+                    const metaSnapshot = state.meta as Partial<{
+                        loose: boolean;
+                        delimiter: string;
+                        marker: string;
+                    }>;
                     const {
                         loose,
                         delimiter = orderListDelimiter,
                         marker = bulletListMarker,
-                    } = state.meta as any;
+                    } = metaSnapshot;
                     if (label === 'task-list') {
                         state.children.forEach((listItem) => {
                             listItem.name = 'task-list-item';
-                            (listItem as any).meta = {
+                            (listItem as ITaskListItemState).meta = {
                                 checked: false,
                             };
                         });
-                        state.meta = {
-                            marker,
-                            loose,
+                        (state as ITaskListState).meta = {
+                            marker: marker ?? bulletListMarker,
+                            loose: !!loose,
                         };
                     }
                     else if (label === 'order-list') {
-                        (state as any).meta = {
+                        (state as IOrderListState).meta = {
                             delimiter,
-                            loose,
+                            loose: !!loose,
+                            start: 1,
                         };
                     }
                     else {
                         state.meta = {
-                            marker,
-                            loose,
+                            marker: marker ?? bulletListMarker,
+                            loose: !!loose,
                         };
                     }
                     // TODO: @JOCS, remove use this.selection directly.
@@ -322,8 +335,10 @@ export class ParagraphFrontMenu extends BaseFloat {
                     if (guessCursorBlock && isSelectionInSameBlock) {
                         const begin = Math.min(anchor!.offset, focus!.offset);
                         const end = Math.max(anchor!.offset, focus!.offset);
-                        // Make guessCursorBlock active
-                        guessCursorBlock.setCursor(begin, end, true);
+                        // Make guessCursorBlock active. queryBlock returns the
+                        // closest block at the given path; for an inline path
+                        // it's a Content leaf (which has setCursor).
+                        (guessCursorBlock as Content).setCursor(begin, end, true);
                     }
                     else {
                         cursorBlock = listBlock.firstContentInDescendant();

--- a/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/hint.spec.ts
+++ b/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/hint.spec.ts
@@ -20,17 +20,16 @@ import { Muya } from '../../../muya';
 // not the CSS rule itself.
 
 const HINT_CLASS = CLASS_NAMES.MU_SHOW_QUICK_INSERT_HINT;
-const MUYA_VERSION_KEY = 'MUYA_VERSION';
 const bootedHosts: HTMLElement[] = [];
-let originalVersion: unknown;
+let originalVersion: string | undefined;
 let hadVersion = false;
 
 beforeEach(() => {
     // happy-dom does not define MUYA_VERSION; Muya reads window.MUYA_VERSION
     // at construct time. Save the current value so afterEach can restore it.
-    hadVersion = MUYA_VERSION_KEY in window;
-    originalVersion = (window as any)[MUYA_VERSION_KEY];
-    (window as any)[MUYA_VERSION_KEY] = 'test';
+    hadVersion = 'MUYA_VERSION' in window;
+    originalVersion = window.MUYA_VERSION;
+    window.MUYA_VERSION = 'test';
 });
 
 afterEach(() => {
@@ -43,9 +42,9 @@ afterEach(() => {
     // Restore the pre-test value of window.MUYA_VERSION (delete if it was
     // unset before we ran).
     if (hadVersion)
-        (window as any)[MUYA_VERSION_KEY] = originalVersion;
+        window.MUYA_VERSION = originalVersion as string;
     else
-        delete (window as any)[MUYA_VERSION_KEY];
+        delete (window as Partial<Window>).MUYA_VERSION;
 });
 
 function bootMuya(options: Partial<ConstructorParameters<typeof Muya>[1]> = {}) {
@@ -53,7 +52,7 @@ function bootMuya(options: Partial<ConstructorParameters<typeof Muya>[1]> = {}) 
     document.body.appendChild(host);
     // Constructor wires up the container; we never call init() so no blocks
     // are registered and no editor lifecycle is started.
-    const muya = new Muya(host, options as any);
+    const muya = new Muya(host, options as ConstructorParameters<typeof Muya>[1]);
     // Track the post-`getContainer` node (host is replaced in place, so the
     // new container shares the body parent).
     bootedHosts.push(muya.domNode);

--- a/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
+++ b/packages/core/src/ui/paragraphQuickInsertMenu/__tests__/replaceBlockByLabel.spec.ts
@@ -1,7 +1,27 @@
 // @vitest-environment happy-dom
+import type Parent from '../../../block/base/parent';
+import type { IConstructor } from '../../../block/types';
+import type { Muya } from '../../../index';
 import { describe, expect, it, vi } from 'vitest';
 import { ScrollPage } from '../../../block/scrollPage';
 import { replaceBlockByLabel } from '../config';
+
+// Loose mock-block shape the tests build via `makeFakeBlock` /
+// `makeFakeOriginBlock`. These don't satisfy the full Parent surface — the
+// production helper only touches the methods listed here, so we keep the
+// surface narrow and cast at the boundary instead of dragging `any` in.
+interface IFakeBlockState {
+    name: string;
+    meta?: Record<string, unknown>;
+    children: IFakeBlockState[];
+    text?: string;
+}
+interface IFakeBlock {
+    state?: IFakeBlockState;
+    parent?: { insertAfter: ReturnType<typeof vi.fn> };
+    replaceWith: ReturnType<typeof vi.fn>;
+    firstContentInDescendant?: () => { text: string; setCursor: ReturnType<typeof vi.fn> };
+}
 
 // Regression for marktext 8891287b "fix paragraph turn into list bug (#1025)".
 //
@@ -27,7 +47,7 @@ import { replaceBlockByLabel } from '../config';
 
 interface ICapturedCreate {
     label: string;
-    state: any;
+    state: IFakeBlockState;
 }
 
 function setupCreateSpy(): {
@@ -37,14 +57,16 @@ function setupCreateSpy(): {
     const captured: ICapturedCreate[] = [];
     const realLoadBlock = ScrollPage.loadBlock.bind(ScrollPage);
     const spy = vi.spyOn(ScrollPage, 'loadBlock').mockImplementation((label: string) => {
-        return {
-            create: (_muya: any, state: any) => {
+        const ctor = {
+            blockName: label,
+            create: (_muya: Muya, state: IFakeBlockState) => {
                 captured.push({ label, state });
                 // Return a fake block with the surface `replaceBlockByLabel`
                 // touches afterwards (`replaceWith` / `firstContentInDescendant`).
                 return makeFakeBlock(state);
             },
-        } as any;
+        };
+        return ctor as unknown as IConstructor<Parent>;
     });
 
     return {
@@ -57,8 +79,8 @@ function setupCreateSpy(): {
     };
 }
 
-function makeFakeBlock(state: any): any {
-    const fake: any = {
+function makeFakeBlock(state: IFakeBlockState): IFakeBlock {
+    return {
         state,
         parent: { insertAfter: vi.fn() },
         replaceWith: vi.fn(),
@@ -67,16 +89,15 @@ function makeFakeBlock(state: any): any {
             setCursor: vi.fn(),
         }),
     };
-    return fake;
 }
 
-function makeFakeOriginBlock(): any {
+function makeFakeOriginBlock(): Parent {
     return {
         replaceWith: vi.fn(),
-    };
+    } as unknown as Parent;
 }
 
-function makeFakeMuya(): any {
+function makeFakeMuya(): Muya {
     return {
         options: {
             preferLooseListItem: false,
@@ -84,7 +105,7 @@ function makeFakeMuya(): any {
             orderListDelimiter: '.',
             frontmatterType: '---',
         },
-    };
+    } as unknown as Muya;
 }
 
 describe('replaceBlockByLabel — paragraph→list keeps text verbatim (marktext 8891287b)', () => {

--- a/packages/core/src/ui/tableChessboard/index.ts
+++ b/packages/core/src/ui/tableChessboard/index.ts
@@ -1,3 +1,4 @@
+import type { ReferenceElement } from '@floating-ui/dom';
 import type { VNode } from 'snabbdom';
 import type { Muya } from '../../index';
 import { EVENT_KEYS } from '../../config';
@@ -166,7 +167,7 @@ class TablePicker extends BaseFloat {
         }
     }
 
-    showPicker(current: ICheckerCount, reference: any, cb: (...args: any[]) => void) {
+    showPicker(current: ICheckerCount, reference: ReferenceElement, cb: (row: number, column: number) => void) {
     // current { row, column } zero base
         this._current = this._select = current;
         super.show(reference, cb);

--- a/packages/core/src/utils/__tests__/getLinkInfo.spec.ts
+++ b/packages/core/src/utils/__tests__/getLinkInfo.spec.ts
@@ -21,8 +21,11 @@ function makeEl(tag: 'a' | 'span', dataset: Record<string, string>, attrs: Recor
         el.dataset[k] = v;
     for (const [k, v] of Object.entries(attrs))
         el.setAttribute(k, v);
+    // Set ad-hoc DOM properties (e.g. `href` on a <span>) that aren't on
+    // the static HTMLElement type. The structural cast captures that
+    // intent without spreading `any` through the helper.
     for (const [k, v] of Object.entries(props))
-        (el as any)[k] = v;
+        (el as unknown as Record<string, string>)[k] = v;
     return el;
 }
 

--- a/packages/core/src/utils/__tests__/search.spec.ts
+++ b/packages/core/src/utils/__tests__/search.spec.ts
@@ -11,7 +11,9 @@ import { buildRegexValue } from '../search';
 // expansion when users rely on regex replace.
 function makeMatch(matchText: string, subMatches: string[]): IMatch {
     return {
-        block: null as any,
+        // `buildRegexValue` only reads .match / .subMatches; the `block`
+        // field is required by the IMatch type but never consulted here.
+        block: null as unknown as IMatch['block'],
         start: 0,
         end: matchText.length,
         match: matchText,

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -10,7 +10,10 @@ interface IUnion {
     active?: boolean;
 }
 
-type Constructor = new (...args: any[]) => object;
+// `never[]` in the contravariant arg-tuple position lets the @methodMixins
+// decorator accept any concrete class constructor (`new (muya: Muya, …)`),
+// without dragging the loosely-typed `any[]` back in.
+type Constructor = new (...args: never[]) => object;
 
 interface IDefer<T> {
     resolve: (value: T) => void;
@@ -77,37 +80,43 @@ export function union({ start: tStart, end: tEnd }: IUnion, { start: lStart, end
 
 // https://github.com/jashkenas/underscore
 // TODO: @jocs rewrite in the future.
-export function throttle(func: any, wait = 50) {
-    let context: any;
-    let args: any;
-    let result: any;
-    let timeout: any = null;
+export function throttle<TArgs extends unknown[], TReturn>(
+    func: (...args: TArgs) => TReturn,
+    wait = 50,
+): (...args: TArgs) => TReturn | undefined {
+    let context: unknown;
+    let pendingArgs: TArgs | null = null;
+    let result: TReturn | undefined;
+    let timeout: ReturnType<typeof setTimeout> | null = null;
     let previous = 0;
     const later = () => {
         previous = Date.now();
         timeout = null;
-        result = func.apply(context, args);
-        if (!timeout)
-            context = args = null;
+        result = func.apply(context, pendingArgs ?? ([] as unknown as TArgs));
+        if (!timeout) {
+            context = null;
+            pendingArgs = null;
+        }
     };
 
-    return function (this: any) {
+    return function (this: unknown, ...callArgs: TArgs): TReturn | undefined {
         const now = Date.now();
         const remaining = wait - (now - previous);
 
         // eslint-disable-next-line ts/no-this-alias
         context = this;
-        // eslint-disable-next-line prefer-rest-params
-        args = arguments;
+        pendingArgs = callArgs;
         if (remaining <= 0 || remaining > wait) {
             if (timeout) {
                 clearTimeout(timeout);
                 timeout = null;
             }
             previous = now;
-            result = func.apply(context, args);
-            if (!timeout)
-                context = args = null;
+            result = func.apply(context, pendingArgs);
+            if (!timeout) {
+                context = null;
+                pendingArgs = null;
+            }
         }
         else if (!timeout) {
             timeout = setTimeout(later, remaining);
@@ -201,7 +210,7 @@ export function getParagraphReference(ele: HTMLElement, id: string) {
 }
 
 function visibleLength(str: string) {
-    return [...new (Intl as any).Segmenter().segment(str)].length;
+    return [...new Intl.Segmenter().segment(str)].length;
 }
 
 export type TDiff = (string | number | { d: string });
@@ -262,7 +271,15 @@ export function verticalPositionInRect(event: MouseEvent, rect: DOMRect) {
     return clientY - top > height / 2 ? 'down' : 'up';
 }
 
-export const hasPick = (c: any) => c && (c.p != null || c.r !== undefined);
+// `hasPick` is called by editor.updateContents on each element of an
+// ot-json1 op descent. The element shape is one of (number | string |
+// JSONOpComponent | JSONOpList) — only the component case (`{p?, r?, ...}`)
+// is interesting. Accept the structural subset we actually read instead of
+// dragging in the whole union (most callers pass an already-narrowed
+// object).
+export function hasPick(c: { p?: number; r?: unknown } | null | undefined): boolean {
+    return !!c && (c.p != null || c.r !== undefined);
+}
 
 export function getDefer<T>() {
     const defer: IDefer<T> = {} as IDefer<T>;
@@ -275,7 +292,12 @@ export function getDefer<T>() {
     return defer;
 }
 
-export function methodMixins(...objects: Record<string, (...args: any[]) => any>[]) {
+export function methodMixins(
+    // `never[]` in the arg-tuple position (contravariant) accepts any
+    // function shape — the inlineSyntaxRenderer mixin map has methods with
+    // wildly different signatures (`backlashInToken`, `header`, `link`…).
+    ...objects: Record<string, (...args: never[]) => unknown>[]
+) {
     return (constructor: Constructor) => {
         for (const object of objects) {
             Object.keys(object).forEach((name) => {

--- a/packages/core/src/utils/marked/extensions/__tests__/footnote.spec.ts
+++ b/packages/core/src/utils/marked/extensions/__tests__/footnote.spec.ts
@@ -20,7 +20,18 @@ interface ISimplifiedToken {
     children?: ISimplifiedToken[];
 }
 
-function simplify(token: any): ISimplifiedToken {
+// Structural view of a lexer-emitted token used by the recursive simplify
+// helper. The lexer hands us a discriminated union we don't fully type
+// here (it's deep), so we accept any record with the optional fields the
+// helper actually reads.
+interface ILexerToken {
+    type: string;
+    identifier?: string;
+    text?: string;
+    tokens?: ILexerToken[];
+}
+
+function simplify(token: ILexerToken): ISimplifiedToken {
     const out: ISimplifiedToken = { type: token.type };
     if (token.identifier !== undefined) {
         out.identifier = token.identifier;
@@ -192,7 +203,7 @@ At vero eos [^foo1]: et accusam.`);
 [^1]: see $a + b$ for the formula`,
             { footnote: true, math: true, frontMatter: false },
         );
-        const footnote = tokens.find(t => t.type === 'footnote') as any;
+        const footnote = tokens.find(t => t.type === 'footnote') as Extract<typeof tokens[number], { type: 'footnote' }> | undefined;
         expect(footnote).toBeDefined();
         // The inline math `$a + b$` lives inside the footnote's paragraph
         // children, but block lexing produces a paragraph token whose
@@ -200,7 +211,7 @@ At vero eos [^foo1]: et accusam.`);
         // parse phase. Asserting the lexer state at the block level is
         // enough — the key invariant is that the footnote re-uses the
         // same lexer, so the extensions match.
-        expect(footnote.tokens.length).toBeGreaterThan(0);
+        expect(footnote!.tokens.length).toBeGreaterThan(0);
     });
 
     it('footnote support is gated by the `footnote` option (default off)', () => {

--- a/packages/core/src/utils/marked/lexBlock.ts
+++ b/packages/core/src/utils/marked/lexBlock.ts
@@ -1,5 +1,5 @@
 import type { Token } from 'marked';
-import type { Heading, ILexOption, ListToken } from './types';
+import type { IFrontmatterToken, ILexOption, TLexedToken } from './types';
 import { Marked } from 'marked';
 import compatibleTaskList from './compatibleTaskList';
 import footnoteExtension from './extensions/footnote';
@@ -11,10 +11,10 @@ import walkTokens from './walkTokens';
 export function lexBlock(
     src: string,
     options: ILexOption = DEFAULT_OPTIONS,
-): (Token | ListToken | Heading)[] {
+): TLexedToken[] {
     options = Object.assign({}, DEFAULT_OPTIONS, options);
     const { math, frontMatter, footnote } = options;
-    let tokens = [];
+    let tokens: (Token | IFrontmatterToken)[] = [];
 
     // Use a per-call Marked instance so extensions don't bleed across calls.
     // marked.use() on the global singleton would make math / footnote sticky:
@@ -45,8 +45,12 @@ export function lexBlock(
     // Pass `m.defaults` to the Lexer so the extensions registered via m.use()
     // are picked up; the no-arg constructor would fall back to global defaults.
     tokens.push(...new m.Lexer(m.defaults).blockTokens(src));
-    tokens = compatibleTaskList(tokens);
-    m.walkTokens(tokens, walkTokens(options));
+    tokens = compatibleTaskList(tokens as Token[]);
+    m.walkTokens(tokens as Token[], walkTokens(options));
 
-    return tokens;
+    // After walkTokens / compatibleTaskList run, marked's Heading/List/ListItem
+    // tokens have been augmented with muya-specific fields (headingStyle,
+    // marker, listType, listItemType, bulletMarkerOrDelimiter). The wider
+    // TLexedToken union captures that runtime shape.
+    return tokens as TLexedToken[];
 }

--- a/packages/core/src/utils/marked/types.ts
+++ b/packages/core/src/utils/marked/types.ts
@@ -1,4 +1,4 @@
-import type { Tokens } from 'marked';
+import type { MarkedToken, Tokens } from 'marked';
 
 export interface ILexOption {
     footnote?: boolean;
@@ -22,3 +22,54 @@ export type ListToken = Tokens.List & {
     listType: 'order' | 'bullet' | 'task';
     items: ListItemToken[];
 };
+
+// Block-level tokens emitted by extensions (footnote, math, frontmatter)
+// plus the synthetic block-end marker `markdownToState` injects to pop the
+// parent stack when descending into block-quote / list / list-item / footnote.
+export interface IFootnoteToken {
+    type: 'footnote';
+    raw: string;
+    identifier: string;
+    tokens: Tokens.Generic[];
+}
+
+export interface IMultipleMathToken {
+    type: 'multiplemath';
+    raw: string;
+    text: string;
+    displayMode: boolean;
+    mathStyle: '' | 'gitlab';
+}
+
+export interface IFrontmatterToken {
+    type: 'frontmatter';
+    raw: string;
+    text: string;
+    style: '-' | '+' | ';' | '{';
+    lang: 'yaml' | 'toml' | 'json';
+}
+
+export interface IBlockEndToken {
+    type: 'block-end';
+    tokenType: 'blockquote' | 'list' | 'list-item' | 'footnote';
+}
+
+// Tokens the lexer (lexBlock) emits. Replace marked's default
+// heading/list/list-item with their muya-extended counterparts so the
+// switch in `markdownToState` narrows to the extension fields directly.
+// We use `MarkedToken` (the discriminated union) rather than `Token`
+// (= MarkedToken | Tokens.Generic) so cases like `'table'` narrow cleanly
+// to `Tokens.Table` instead of `Tokens.Table | Tokens.Generic` — the
+// latter would poison field access with the Generic's `[index: string]: any`.
+export type TLexedToken
+    = | Exclude<MarkedToken, Tokens.Heading | Tokens.List | Tokens.ListItem>
+        | Heading
+        | ListToken
+        | ListItemToken
+        | IFootnoteToken
+        | IMultipleMathToken
+        | IFrontmatterToken;
+
+// The working token stream `markdownToState` walks: lexer output plus the
+// synthetic `block-end` markers it injects to pop the parent stack.
+export type TBlockToken = TLexedToken | IBlockEndToken;

--- a/packages/core/src/utils/prism/loadLanguage.ts
+++ b/packages/core/src/utils/prism/loadLanguage.ts
@@ -54,7 +54,13 @@ export function transformAliasToOrigin(langs: string[]) {
     return result;
 }
 
-function initLoadLanguage(Prism: any) {
+// Minimal Prism surface this module needs — full Prism typings live in
+// prismjs's external @types package, but we only read `languages` here.
+interface IPrismLike {
+    languages: Record<string, unknown>;
+}
+
+function initLoadLanguage(Prism: IPrismLike) {
     return async function loadLanguages(langs?: string[] | string) {
     // If no argument is passed, load all components
         if (!langs)


### PR DESCRIPTION
## Summary

- Replaces **~220 occurrences of `any`** (148 `as any`, 54 `: any`, 16 `any[]`) across 57 files with concrete types, narrow `as unknown as X` casts at boundaries, or `eslint-disable-with-comment` for the two sanctioned escape hatches.
- Enables `ts/no-explicit-any: 'error'` in `eslint.config.mjs` so new `any` fails lint.
- Surfaces two latent bugs the `any` was hiding (RegExp null check + diagram lang narrowing in `markdownToState.ts`) — both fixed without behavior change.

## Type infrastructure added

- **`utils/marked/types.ts`** — extends marked's `Token` union with muya extension fields (`Heading.headingStyle`, `ListToken.listType`, footnote/multiplemath/frontmatter/block-end tokens) and exports `TLexedToken` / `TBlockToken`. Lets `markdownToState`'s `switch (token.type)` narrow without `as any`.
- **`types/global.d.ts`** — declares `Intl.Segmenter` (ES2022, missing from the ES2020 TS lib target).
- **`examples/src/vite-env.d.ts`** — declares `window.muya` + `Intl.Segmenter` for the examples app.
- **`inlineRenderer/renderer/index.ts`** — adds a typed `dispatch()` helper that replaces five `(this as any)[snakeToCamel(token.type)]` call sites.

## Sanctioned escape hatches (kept with eslint-disable + comment)

- `event/types.ts::Listener` — heterogeneous per-event payloads; typed alternatives are invasive enough to be a follow-up.
- `block/types.ts::IConstructor.create` — block registry holds heterogeneous block constructors; concrete subclasses narrow `state` to their `I…State` interface.

## Test plan

- [x] `pnpm lint` — 0 errors (25 warnings, all pre-existing complexity / naming).
- [x] `pnpm lint:types` — clean.
- [x] `pnpm test` — 386/386 passing.
- [x] `pnpm --filter @muyajs/core test:spec` — 1347/1347 passing (CommonMark + GFM fixture suites).
- [x] `pnpm check-circular` — no circular dependencies.
- [x] `pnpm build` — clean.
- [x] `pnpm dev` — examples app boots and serves at http://localhost:5174.
- [ ] Manual browser smoke test: typing, formatting toolbar, lists, tables, links, image insert, language switcher.

## Notes for reviewers

- Most call sites of `loadBlock(...).create(...)` historically returned `any`; the registry is typed `IConstructor<Parent>` now but `create` still returns `any` (with a single eslint-disable) to preserve the downstream chain (`firstContentInDescendant().setCursor(…)`) without forcing nullable-check refactors across every block subclass.
- `selection/index.ts` keeps a single `as unknown as Node` cast where `scrollPage?.queryBlock(anchorPath)` is passed to `getNodeAndOffset`. This is a pre-existing semantic gap (the branch was never type-checked under `any`); fixing the contract is out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)