### PR TITLE
docs(examples): full-coverage playground with sidebar control panel

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,4 +1,4 @@
 {
   "*.ts": ["eslint --fix"],
-  "*.{html,css}": ["stylelint \"**/*.css\" --fix"]
+  "*.css": ["stylelint --fix"]
 }

--- a/examples/index.html
+++ b/examples/index.html
@@ -7,6 +7,7 @@
         <title>Muya Playground</title>
     </head>
     <body>
+        <button id="sidebar-toggle" class="sidebar-toggle" type="button" aria-label="Toggle sidebar" title="Toggle sidebar">☰</button>
         <aside class="sidebar">
             <header class="sidebar-brand">Muya Playground</header>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,32 +4,185 @@
         <meta charset="UTF-8" />
         <link rel="icon" type="image/svg+xml" href="/logo.jpg" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-        <title>Muya Example</title>
+        <title>Muya Playground</title>
     </head>
     <body>
-        <div class="tools">
-            <div class="language-selector">
+        <aside class="sidebar">
+            <header class="sidebar-brand">Muya Playground</header>
+
+            <details open>
+                <summary>Locale</summary>
                 <label for="language-select">Language:</label>
                 <select id="language-select">
                     <option value="zh">中文</option>
                     <option value="en">English</option>
                     <option value="ja">日本語</option>
                 </select>
-            </div>
-            <button id="undo">UNDO</button>
-            <button id="redo">REDO</button>
-            <input id="search" type="text" placeholder="Search text..." />
-            <button id="previous">Previous</button>
-            <button id="next">Next</button>
-            <input id="replace" type="text" placeholder="Replace text..." />
-            <button id="single">Single</button>
-            <button id="all">All</button>
-            <button id="set-content">Set Content</button>
-            <button id="select-all">Select All</button>
-        </div>
-        <div class="editor-container">
+            </details>
+
+            <details open>
+                <summary>History &amp; Selection</summary>
+                <button id="undo">Undo</button>
+                <button id="redo">Redo</button>
+                <button id="select-all">Select All</button>
+                <button id="focus">Focus editor</button>
+            </details>
+
+            <details open>
+                <summary>Find &amp; Replace</summary>
+                <input id="search" type="text" placeholder="Search (regexp)…" />
+                <div class="sidebar-row">
+                    <button id="previous">Previous</button>
+                    <button id="next">Next</button>
+                </div>
+                <input id="replace" type="text" placeholder="Replacement text…" />
+                <div class="sidebar-row">
+                    <button id="single">Replace</button>
+                    <button id="all">Replace All</button>
+                </div>
+            </details>
+
+            <details open>
+                <summary>Content</summary>
+                <button id="set-content">Set Content (minimal)</button>
+                <button id="reset-demo">Reset to demo</button>
+                <button id="clear-all">Clear all</button>
+            </details>
+
+            <details open>
+                <summary>Export &amp; Debug</summary>
+                <div class="sidebar-row">
+                    <button id="show-md">Show MD</button>
+                    <button id="show-state">Show State</button>
+                </div>
+                <div class="sidebar-row">
+                    <button id="show-toc">Show TOC</button>
+                    <button id="export-html">Export HTML</button>
+                </div>
+                <textarea id="debug-out" readonly placeholder="Output appears here…"></textarea>
+            </details>
+
+            <details open>
+                <summary>Muya Options <span class="sidebar-hint">(Apply to reload)</span></summary>
+                <form id="options-form">
+                    <fieldset>
+                        <legend>Markdown extensions</legend>
+                        <label><input type="checkbox" data-opt="frontMatter" /> frontMatter</label>
+                        <label><input type="checkbox" data-opt="footnote" /> footnote</label>
+                        <label><input type="checkbox" data-opt="math" /> math</label>
+                        <label><input type="checkbox" data-opt="superSubScript" /> superSubScript</label>
+                        <label><input type="checkbox" data-opt="isGitlabCompatibilityEnabled" /> isGitlabCompatibilityEnabled</label>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>Display</legend>
+                        <label><input type="checkbox" data-opt="codeBlockLineNumbers" /> codeBlockLineNumbers</label>
+                        <label><input type="checkbox" data-opt="focusMode" /> focusMode</label>
+                        <label><input type="checkbox" data-opt="spellcheckEnabled" /> spellcheckEnabled</label>
+                        <label><input type="checkbox" data-opt="disableHtml" /> disableHtml</label>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>Editing behavior</legend>
+                        <label><input type="checkbox" data-opt="autoPairBracket" /> autoPairBracket</label>
+                        <label><input type="checkbox" data-opt="autoPairMarkdownSyntax" /> autoPairMarkdownSyntax</label>
+                        <label><input type="checkbox" data-opt="autoPairQuote" /> autoPairQuote</label>
+                        <label><input type="checkbox" data-opt="autoCheck" /> autoCheck</label>
+                        <label><input type="checkbox" data-opt="autoMoveCheckedToEnd" /> autoMoveCheckedToEnd</label>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>Misc</legend>
+                        <label><input type="checkbox" data-opt="preferLooseListItem" /> preferLooseListItem</label>
+                        <label><input type="checkbox" data-opt="hideQuickInsertHint" /> hideQuickInsertHint</label>
+                        <label><input type="checkbox" data-opt="hideLinkPopup" /> hideLinkPopup</label>
+                        <label><input type="checkbox" data-opt="trimUnnecessaryCodeBlockEmptyLines" /> trimUnnecessaryCodeBlockEmptyLines</label>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>bulletListMarker</legend>
+                        <label><input type="radio" name="opt-bulletListMarker" value="-" /> -</label>
+                        <label><input type="radio" name="opt-bulletListMarker" value="+" /> +</label>
+                        <label><input type="radio" name="opt-bulletListMarker" value="*" /> *</label>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>orderListDelimiter</legend>
+                        <label><input type="radio" name="opt-orderListDelimiter" value="." /> .</label>
+                        <label><input type="radio" name="opt-orderListDelimiter" value=")" /> )</label>
+                    </fieldset>
+
+                    <fieldset>
+                        <legend>frontmatterType</legend>
+                        <label><input type="radio" name="opt-frontmatterType" value="-" /> - (YAML)</label>
+                        <label><input type="radio" name="opt-frontmatterType" value="+" /> + (TOML)</label>
+                        <label><input type="radio" name="opt-frontmatterType" value=";" /> ; (JSON ;;;)</label>
+                        <label><input type="radio" name="opt-frontmatterType" value="{" /> { (JSON {})</label>
+                    </fieldset>
+
+                    <label class="sidebar-field">
+                        <span>mermaidTheme</span>
+                        <select data-opt="mermaidTheme">
+                            <option value="default">default</option>
+                            <option value="dark">dark</option>
+                            <option value="forest">forest</option>
+                        </select>
+                    </label>
+
+                    <label class="sidebar-field">
+                        <span>vegaTheme</span>
+                        <select data-opt="vegaTheme">
+                            <option value="latimes">latimes</option>
+                            <option value="excel">excel</option>
+                            <option value="ggplot2">ggplot2</option>
+                            <option value="quartz">quartz</option>
+                            <option value="vox">vox</option>
+                            <option value="fivethirtyeight">fivethirtyeight</option>
+                            <option value="dark">dark</option>
+                        </select>
+                    </label>
+
+                    <label class="sidebar-field">
+                        <span>fontSize (px)</span>
+                        <input type="number" data-opt="fontSize" min="8" max="32" step="1" />
+                    </label>
+                    <label class="sidebar-field">
+                        <span>lineHeight</span>
+                        <input type="number" data-opt="lineHeight" min="1" max="3" step="0.1" />
+                    </label>
+                    <label class="sidebar-field">
+                        <span>tabSize</span>
+                        <input type="number" data-opt="tabSize" min="2" max="8" step="1" />
+                    </label>
+                    <label class="sidebar-field">
+                        <span>listIndentation</span>
+                        <input type="number" data-opt="listIndentation" min="1" max="4" step="1" />
+                    </label>
+                </form>
+                <button id="apply-options" type="button">Apply settings &amp; reload</button>
+            </details>
+
+            <details open>
+                <summary>UI plugin hints</summary>
+                <ul class="sidebar-hints">
+                    <li>Hover the left margin of any paragraph → drag handle + paragraph menu (heading / list / quote conversion).</li>
+                    <li>Select text → inline format toolbar (B / I / Code / Link / …).</li>
+                    <li>Type <code>/</code> in an empty paragraph → quick insert menu.</li>
+                    <li>Type <code>:</code> → emoji picker.</li>
+                    <li>Hover a table row / column → drag bar, row-col menu, column toolbar.</li>
+                    <li>Hover an image → resize handles + image toolbar; click an empty image placeholder → image edit tool.</li>
+                    <li>Click the language label of a code block → language selector.</li>
+                    <li>Hover a link → link tools (edit / open / unlink).</li>
+                    <li>Hover a footnote reference → footnote editor.</li>
+                    <li>Hover a diagram / math / html block → preview toolbar (source ↔ preview).</li>
+                </ul>
+            </details>
+        </aside>
+
+        <main class="editor-container">
             <div id="editor"></div>
-        </div>
+        </main>
+
         <script type="module" src="/src/main.ts"></script>
     </body>
 </html>

--- a/examples/src/data.ts
+++ b/examples/src/data.ts
@@ -1,3 +1,8 @@
+// Reference shapes for several common block types — not exhaustive
+// (footnote, html-preview/container, math/diagram containers, and other
+// internal/attachment blocks are not represented). Not consumed at
+// runtime; kept as a quick lookup for plugin authors who need to
+// construct JSON state directly instead of going through markdown.
 export const DEFAULT_STATE = [
     {
         name: 'frontmatter',
@@ -18,31 +23,17 @@ export const DEFAULT_STATE = [
         name: 'paragraph',
         text: '**strong** *emphasis* `inline code` &gt; <u>underline</u> <mark>highlight</mark> <ruby>北京<rt>Beijing</rt></ruby> [Baidu](http://www.baidu.com) H0~2~ X^5^',
     },
-    // Setext headings
     {
         name: 'setext-heading',
         meta: {
             level: 1,
             underline: '===', // === or ---
         },
-        text: 'GitHub and Extra\nInline format', // can contain multiple lines.
+        text: 'GitHub and Extra\nInline format',
     },
     {
         name: 'paragraph',
         text: ':man:  ~~del~~ http://google.com $a \\ne b$',
-    },
-    {
-        name: 'atx-heading',
-        meta: {
-            level: 1, // 1 ~ 6
-        },
-        text: '# Line Break', // can not contain `\n`!
-    },
-    {
-        name: 'paragraph',
-        text: `soft line break
-hard line break  
-line end`,
     },
     {
         name: 'diagram',
@@ -57,22 +48,10 @@ line end`,
         },
     },
     {
-        name: 'diagram',
-        text: `@startuml
-Alice -> Bob: Authentication Request
-Bob --> Alice: Authentication Response
-@enduml`,
-        meta: {
-            lang: 'yaml',
-            type: 'plantuml',
-        },
-    },
-    // Indented code blocks and Fenced code blocks
-    {
         name: 'code-block',
         meta: {
-            type: 'indented', // indented or fenced
-            lang: 'javascript', // lang will be empty string if block is indented block. set language will auto change into fenced code block.
+            type: 'indented',
+            lang: 'javascript',
         },
         text: 'const foo = `bar`',
     },
@@ -87,188 +66,84 @@ Bob --> Alice: Authentication Response
         name: 'html-block',
         text: '<div>\nfoo bar\n</div>',
     },
-    // Table
     {
         name: 'table',
         children: [
             {
                 name: 'table.row',
                 children: [
-                    {
-                        name: 'table.cell',
-                        meta: {
-                            align: 'right', // none left center right, cells in the same column has the same alignment.
-                        },
-                        text: 'foo',
-                    },
-                    {
-                        name: 'table.cell',
-                        meta: {
-                            align: 'none', // none left center right, cells in the same column has the same alignment.
-                        },
-                        text: 'bar',
-                    },
+                    { name: 'table.cell', meta: { align: 'right' }, text: 'foo' },
+                    { name: 'table.cell', meta: { align: 'none' }, text: 'bar' },
                 ],
             },
             {
                 name: 'table.row',
                 children: [
-                    {
-                        name: 'table.cell',
-                        meta: {
-                            align: 'right', // none left center right, cells in the same column has the same alignment.
-                        },
-                        text: 'zar',
-                    },
-                    {
-                        name: 'table.cell',
-                        meta: {
-                            align: 'none', // none left center right, cells in the same column has the same alignment.
-                        },
-                        text: 'foo bar',
-                    },
+                    { name: 'table.cell', meta: { align: 'right' }, text: 'zar' },
+                    { name: 'table.cell', meta: { align: 'none' }, text: 'foo bar' },
                 ],
             },
         ],
     },
-    // Indented code blocks and Fenced code blocks
-    // Order List Blocks
     {
         name: 'order-list',
-        meta: {
-            start: 0, // 0 ~ 999999999
-            loose: true, // true or false, true is loose list and false is tight.
-            delimiter: '.', // . or )
-        },
+        meta: { start: 0, loose: true, delimiter: '.' },
         children: [
-            // List Item
             {
-                name: 'list-item', // Can contains any type and number of leaf blocks.
-                children: [
-                    {
-                        name: 'paragraph',
-                        text: 'foo\nbar',
-                    },
-                ],
+                name: 'list-item',
+                children: [{ name: 'paragraph', text: 'foo\nbar' }],
             },
         ],
     },
-    // Bullet List Blocks
     {
         name: 'bullet-list',
-        meta: {
-            marker: '-', // - + *
-            loose: false, // true or false
-        },
+        meta: { marker: '-', loose: false },
         children: [
-            // List Item
             {
-                name: 'list-item', // Can contains any type and number of leaf blocks.
+                name: 'list-item',
                 children: [
-                    {
-                        name: 'paragraph',
-                        text: 'foo bar1',
-                    },
-                    {
-                        name: 'paragraph',
-                        text: 'foo bar2',
-                    },
+                    { name: 'paragraph', text: 'foo bar1' },
+                    { name: 'paragraph', text: 'foo bar2' },
                 ],
             },
         ],
     },
-    // Task List
     {
         name: 'task-list',
-        meta: {
-            marker: '-', // - + *
-        },
+        meta: { marker: '-' },
         children: [
-            {
-                name: 'task-list-item',
-                meta: {
-                    checked: false, // true or false
-                },
-                children: [
-                    {
-                        name: 'paragraph',
-                        text: 'a',
-                    },
-                ],
-            },
-            {
-                name: 'task-list-item',
-                meta: {
-                    checked: true, // true or false
-                },
-                children: [
-                    {
-                        name: 'paragraph',
-                        text: 'b',
-                    },
-                ],
-            },
-            {
-                name: 'task-list-item',
-                meta: {
-                    checked: false, // true or false
-                },
-                children: [
-                    {
-                        name: 'paragraph',
-                        text: 'c',
-                    },
-                ],
-            },
-            {
-                name: 'task-list-item',
-                meta: {
-                    checked: false, // true or false
-                },
-                children: [
-                    {
-                        name: 'paragraph',
-                        text: 'd',
-                    },
-                ],
-            },
+            { name: 'task-list-item', meta: { checked: false }, children: [{ name: 'paragraph', text: 'a' }] },
+            { name: 'task-list-item', meta: { checked: true }, children: [{ name: 'paragraph', text: 'b' }] },
         ],
     },
-    // Thematic breaks
-    {
-        name: 'thematic-break',
-        text: '---', // --- or ___ or ***
-    },
-    // Block quotes
+    { name: 'thematic-break', text: '---' },
     {
         name: 'block-quote',
-        children: [
-            {
-                // Can contains any type and number of leaf blocks.
-                name: 'paragraph',
-                text: 'foo\nbar',
-            },
-        ],
-    },
-    {
-        name: 'paragraph',
-        text: '![](https://jingan2.guankou.net/haopic/jj20/389023/010323033238341796.jpg)',
+        children: [{ name: 'paragraph', text: 'foo\nbar' }],
     },
 ];
 
+// Playground markdown. Organized into ATX chapters so `muya.getTOC()` (in the
+// sidebar "Show TOC" button) doubles as a feature-coverage checklist. Each
+// chapter targets one category of supported features; remove a chapter only
+// if you also remove the corresponding feature from packages/core.
 export const DEFAULT_MARKDOWN = `---
-title: muya
-author: jocs
+title: Muya Playground
+description: Demo coverage for every supported block and inline format
+tags: [muya, editor, demo]
 ---
 
-# Heading levels
+# 1. Headings
 
-# H1 ATX heading
-## H2 ATX heading
-### H3 ATX heading
-#### H4 ATX heading
-##### H5 ATX heading
-###### H6 ATX heading
+## ATX H2
+
+### ATX H3
+
+#### ATX H4
+
+##### ATX H5
+
+###### ATX H6
 
 Setext H1
 =========
@@ -276,184 +151,236 @@ Setext H1
 Setext H2
 ---------
 
-# Inline Format
+# 2. Paragraphs and Line Breaks
 
-**strong** *emphasis* \`inline code\` &gt; <u>underline</u> <mark>highlight</mark> <ruby>北京<rt>Beijing</rt></ruby> [Baidu](http://www.baidu.com) H0~2~ X^5^
+A regular paragraph. The two lines below are joined by a **soft** line break (single newline, no visible \`<br>\`):
 
-# Links (hover for tools)
+first line of soft break
+second line of soft break
 
-Markdown link: [Anthropic](https://www.anthropic.com).
+The two lines below are joined by a **hard** line break (two trailing spaces produce a \`<br>\`):
 
-Reference link: [Wikipedia][wiki] (definition below).
+first line of hard break  
+second line of hard break
 
-HTML anchor: <a href="https://github.com/marktext/muya">marktext/muya on GitHub</a>.
+Backslash escapes: \\* \\_ \\[ \\] \\\\ \\\` produce literal punctuation instead of formatting.
+
+# 3. Inline Formatting
+
+**strong**, *emphasis*, ***both at once***, \`inline code\`, ~~strikethrough~~, inline math $a \\ne b$, super^script^ and sub~script~, emoji :smile: :rocket: :tada:.
+
+# 4. Links and Images
+
+Inline link with title: [Anthropic](https://www.anthropic.com "Hello Claude").
 
 Autolink: <https://commonmark.org>.
 
+Raw URL autolink (GFM extension): https://github.com/marktext/muya.
+
+HTML anchor: <a href="https://github.com/marktext/muya">marktext/muya on GitHub</a>.
+
+Reference link: [Wikipedia][wiki] and shorthand [example].
+
+Reference image: ![marktext logo small][img].
+
+Inline image:
+
+![marktext logo](https://raw.githubusercontent.com/marktext/marktext/develop/static/icon.png "marktext icon")
+
 [wiki]: https://en.wikipedia.org "Wikipedia"
+[example]: https://example.com "Example"
+[img]: https://raw.githubusercontent.com/marktext/marktext/develop/static/logo-96px.png "marktext logo 96px"
 
-GitHub and Extra
-Inline format
-===
+# 5. Inline HTML
 
-:man:  ~~del~~ http://google.com $a \\ne b$
+<u>underline</u>, <mark>highlight</mark>, H<sub>2</sub>O, E=mc<sup>2</sup>, <ruby>北京<rt>Beijing</rt></ruby>.
 
-# Line Break
+HTML entities: &gt; &lt; &amp;.
 
-soft line break
-hard line break  
-line end
+Custom span: <span style="color:#d33">red text</span>.
 
-    const a = "nice"
-    function add(){}
+# 6. Block Quotes
 
-\`\`\`
-const b = "foo"
-\`\`\`
+> Level 1 block quote.
+>
+> > Level 2 nested quote.
+> >
+> > > Level 3 nested quote.
+
+> A quote that contains a list:
+>
+> - item one
+> - item two
+
+# 7. Lists
+
+Bullet list with \`-\` marker:
+
+- dash one
+- dash two
+
+Bullet list with \`+\` marker:
+
++ plus one
++ plus two
+
+Bullet list with \`*\` marker:
+
+* asterisk one
+* asterisk two
+
+Ordered list with \`.\` delimiter:
+
+1. one
+2. two
+3. three
+
+Ordered list with \`)\` delimiter:
+
+1) alpha
+2) beta
+3) gamma
+
+Nested mixed list:
+
+- outer item
+    - nested unordered
+        1. nested ordered
+        2. second
+- outer next
+
+Tight list (no blank lines):
+
+- tight one
+- tight two
+- tight three
+
+Loose list (blank lines between items):
+
+- loose one
+
+- loose two
+
+- loose three
+
+# 8. Task Lists
+
+- [ ] open task
+- [x] completed task
+- [ ] parent task
+    - [x] nested done
+    - [ ] nested pending
+
+# 9. Thematic Breaks
+
+Three dashes:
+
+---
+
+Three asterisks:
+
+***
+
+Three underscores:
+
+___
+
+# 10. Code Blocks
+
+Indented code block (4-space indent):
+
+    const greet = (name) => \`Hello, \${name}!\`;
+    greet('world');
+
+Fenced TypeScript (toggle \`codeBlockLineNumbers\` in the sidebar to see line numbers):
 
 \`\`\`typescript
-// Long fenced code block to showcase PR-5a line numbers
-// (enable via Muya option codeBlockLineNumbers: true).
 import { Muya } from '@muyajs/core';
 
-const container = document.querySelector('#editor')!;
-const muya = new Muya(container, {
+const muya = new Muya(document.querySelector('#editor')!, {
     markdown: '# hello',
     codeBlockLineNumbers: true,
 });
 
 muya.init();
-
-muya.on('json-change', () => {
-    console.log('changed');
-});
-
-muya.on('focus', () => console.log('focus'));
-muya.on('blur', () => console.log('blur'));
+muya.on('json-change', () => console.log('changed'));
 \`\`\`
 
-\`\`\`math
-a \\ne b
+Fenced Python:
+
+\`\`\`python
+def fib(n):
+    a, b = 0, 1
+    for _ in range(n):
+        a, b = b, a + b
+    return a
 \`\`\`
+
+Fenced Bash:
+
+\`\`\`bash
+pnpm install && pnpm dev
+\`\`\`
+
+Fenced JSON:
+
+\`\`\`json
+{
+    "name": "@muyajs/core",
+    "version": "0.2.0"
+}
+\`\`\`
+
+Empty fenced block (toggle \`trimUnnecessaryCodeBlockEmptyLines\` to see how empty lines are handled on import):
+
+\`\`\`
+
+
+\`\`\`
+
+# 11. Math
+
+Block math (KaTeX, requires \`math: true\`):
+
+$$
+\\int_{0}^{\\infty} e^{-x^2} \\,dx = \\frac{\\sqrt{\\pi}}{2}
+$$
+
+# 12. Tables
+
+| Left aligned | Centered | Right aligned |
+| :----------- | :------: | ------------: |
+| **strong**   | \`code\`   | $a \\ne b$     |
+| row 2        | foo \\| bar | 42            |
+
+# 13. Diagrams
+
+Mermaid flowchart:
+
+\`\`\`mermaid
+flowchart TD
+    A[Start] -->|input| B(Process)
+    B --> C{Decision}
+    C -->|yes| D[Result]
+    C -->|no| E[Reject]
+\`\`\`
+
+Mermaid mindmap:
 
 \`\`\`mermaid
 mindmap
-  root((mindmap))
-    Origins
-      Long history
-      ::icon(fa fa-book)
-      Popularisation
-        British popular psychology author Tony Buzan
-    Research
-      On effectiveness<br/>and features
-      On Automatic creation
-        Uses
-            Creative techniques
-            Strategic planning
-            Argument mapping
-    Tools
-      Pen and paper
-      Mermaid
+  root((Muya))
+    Block
+      Headings
+      Lists
+      Tables
+    Inline
+      Strong
+      Emoji
+      Math
 \`\`\`
 
-\`\`\`vega-lite
-{
-  "$schema": "https://vega.github.io/schema/vega/v6.json",
-  "description": "A basic bar chart example, with value labels shown upon pointer hover.",
-  "width": 400,
-  "height": 200,
-  "padding": 5,
-
-  "data": [
-    {
-      "name": "table",
-      "values": [
-        {"category": "A", "amount": 28},
-        {"category": "B", "amount": 55},
-        {"category": "C", "amount": 43},
-        {"category": "D", "amount": 91},
-        {"category": "E", "amount": 81},
-        {"category": "F", "amount": 53},
-        {"category": "G", "amount": 19},
-        {"category": "H", "amount": 87}
-      ]
-    }
-  ],
-
-  "signals": [
-    {
-      "name": "tooltip",
-      "value": {},
-      "on": [
-        {"events": "rect:pointerover", "update": "datum"},
-        {"events": "rect:pointerout",  "update": "{}"}
-      ]
-    }
-  ],
-
-  "scales": [
-    {
-      "name": "xscale",
-      "type": "band",
-      "domain": {"data": "table", "field": "category"},
-      "range": "width",
-      "padding": 0.05,
-      "round": true
-    },
-    {
-      "name": "yscale",
-      "domain": {"data": "table", "field": "amount"},
-      "nice": true,
-      "range": "height"
-    }
-  ],
-
-  "axes": [
-    { "orient": "bottom", "scale": "xscale" },
-    { "orient": "left", "scale": "yscale" }
-  ],
-
-  "marks": [
-    {
-      "type": "rect",
-      "from": {"data":"table"},
-      "encode": {
-        "enter": {
-          "x": {"scale": "xscale", "field": "category"},
-          "width": {"scale": "xscale", "band": 1},
-          "y": {"scale": "yscale", "field": "amount"},
-          "y2": {"scale": "yscale", "value": 0}
-        },
-        "update": {
-          "fill": {"value": "steelblue"}
-        },
-        "hover": {
-          "fill": {"value": "red"}
-        }
-      }
-    },
-    {
-      "type": "text",
-      "encode": {
-        "enter": {
-          "align": {"value": "center"},
-          "baseline": {"value": "bottom"},
-          "fill": {"value": "#333"}
-        },
-        "update": {
-          "x": {"scale": "xscale", "signal": "tooltip.category", "band": 0.5},
-          "y": {"scale": "yscale", "signal": "tooltip.amount", "offset": -2},
-          "text": {"signal": "tooltip.amount"},
-          "fillOpacity": [
-            {"test": "datum === tooltip", "value": 0},
-            {"value": 1}
-          ]
-        }
-      }
-    }
-  ]
-}
-\`\`\`
+PlantUML sequence:
 
 \`\`\`plantuml
 @startuml
@@ -462,45 +389,39 @@ Bob --> Alice: Authentication Response
 @enduml
 \`\`\`
 
-\`\`\`javascript
-const foo = \`bar\`
+Vega-Lite bar chart (swap \`vegaTheme\` in the sidebar to restyle):
+
+\`\`\`vega-lite
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "description": "A simple bar chart with embedded data.",
+  "data": {
+    "values": [
+      {"a": "A", "b": 28}, {"a": "B", "b": 55}, {"a": "C", "b": 43},
+      {"a": "D", "b": 91}, {"a": "E", "b": 81}, {"a": "F", "b": 53},
+      {"a": "G", "b": 19}, {"a": "H", "b": 87}, {"a": "I", "b": 52}
+    ]
+  },
+  "mark": "bar",
+  "encoding": {
+    "x": {"field": "a", "type": "nominal"},
+    "y": {"field": "b", "type": "quantitative"}
+  }
+}
 \`\`\`
 
-$$
-a \\ne b
-$$
+# 14. HTML Block
 
-<div>
-foo bar
+<div style="padding: 12px; border: 1px dashed #999;">
+    <p>This is a raw HTML block.</p>
+    <p>Toggle <code>disableHtml</code> in the sidebar Options panel to see it as source instead.</p>
 </div>
 
-| foo | bar     |
-| ---:| ------- |
-| zar | foo\\|bar |
+# 15. Footnotes
 
-0. foo
-   bar
-- foo bar1
-  
-  foo bar2
+Footnotes require \`footnote: true\` in the Muya options. A paragraph can reference a footnote[^note] and another one[^pandoc].
 
-- [x] a
-- [x] b
-- [ ] c
-- [ ] d
-
----
-
-> foo
-> bar
->
-> > nested quote level 2
-> >
-> > > nested quote level 3
-
-A short paragraph with a footnote reference[^note] and another[^pandoc].
-
-[^note]: This is the first footnote definition. It can span multiple
+[^note]: First footnote definition. It can span multiple
     lines when continuation lines are indented by four spaces.
 
 [^pandoc]: A footnote can also contain nested blocks:
@@ -508,9 +429,7 @@ A short paragraph with a footnote reference[^note] and another[^pandoc].
     - bullet item one
     - bullet item two
 
-![](https://jingan2.guankou.net/haopic/jj20/389023/010323033238341796.jpg)IMAGE
+# 16. Interaction Hints
 
-This is a [reference link][example] and a ![ref image][img].
-
-[example]: https://example.com "Example Title"
-[img]: https://placekitten.com/200/200 "Kitten"`;
+Most editing tools are triggered by mouse or keyboard inside the editor. See the **UI plugin hints** section in the left sidebar for the full list (paragraph menu, format toolbar, quick insert, emoji picker, table tools, image tools, code language picker, link tools, footnote tool, preview toolbar).
+`;

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -1,5 +1,5 @@
 /* eslint-disable antfu/no-top-level-await */
-import type { TState } from '@muyajs/core';
+import type { IMuyaOptions, TState } from '@muyajs/core';
 import {
     CodeBlockLanguageSelector,
     EmojiSelector,
@@ -27,34 +27,32 @@ import { DEFAULT_MARKDOWN } from './data';
 
 import './style.css';
 
-// Fix Intl.Segmenter is not work on firefox.
+// ---------- Firefox Intl.Segmenter polyfill ----------
+
 const intlNs = Intl as unknown as { Segmenter?: typeof Intl.Segmenter };
 if (!intlNs.Segmenter) {
     const polyfill = await import('intl-segmenter-polyfill/dist/bundled');
     intlNs.Segmenter = await polyfill.createIntlSegmenterPolyfill() as typeof Intl.Segmenter;
 }
 
+// ---------- ImageEditTool callbacks ----------
+
 async function imagePathPicker() {
     return 'https://pics.ettoday.net/images/2253/d2253152.jpg';
 }
 
 async function imageAction() {
-    return new Promise((resolve) => {
-        setTimeout(() => {
-            resolve(
-                'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg',
-            );
-        }, 3000);
+    return new Promise<string>((resolve) => {
+        setTimeout(resolve, 3000, 'https://gw.alipayobjects.com/zos/rmsportal/KDpgvguMpGfqaHPjicRK.svg');
     });
 }
+
+// ---------- Register UI plugins (once, applies to every Muya instance) ----------
 
 Muya.use(EmojiSelector);
 Muya.use(FootnoteTool);
 Muya.use(InlineFormatToolbar);
-Muya.use(ImageEditTool, {
-    imagePathPicker,
-    imageAction,
-});
+Muya.use(ImageEditTool, { imagePathPicker, imageAction });
 Muya.use(ImageToolBar);
 Muya.use(ImageResizeBar);
 Muya.use(CodeBlockLanguageSelector);
@@ -65,7 +63,6 @@ Muya.use(LinkTools, {
             window.open(href, '_blank', 'noopener,noreferrer');
     },
 });
-
 Muya.use(ParagraphFrontButton);
 Muya.use(ParagraphFrontMenu);
 Muya.use(TableColumnToolbar);
@@ -74,123 +71,236 @@ Muya.use(TableDragBar);
 Muya.use(TableRowColumMenu);
 Muya.use(PreviewToolBar);
 
-const container: HTMLElement = document.querySelector('#editor')!;
-const undoBtn: HTMLButtonElement = document.querySelector('#undo')!;
-const redoBtn: HTMLButtonElement = document.querySelector('#redo')!;
-const searchInput: HTMLInputElement = document.querySelector('#search')!;
-const previousBtn: HTMLButtonElement = document.querySelector('#previous')!;
-const nextBtn: HTMLButtonElement = document.querySelector('#next')!;
-const replaceInput: HTMLInputElement = document.querySelector('#replace')!;
-const singleBtn: HTMLButtonElement = document.querySelector('#single')!;
-const allBtn: HTMLButtonElement = document.querySelector('#all')!;
-const setContentBtn: HTMLButtonElement = document.querySelector('#set-content')!;
-const selectAllBtn: HTMLButtonElement = document.querySelector('#select-all')!;
+// ---------- Mutable runtime state ----------
 
-const muya = new Muya(container, {
-    markdown: DEFAULT_MARKDOWN,
+const LOCALES = { zh, en, ja } as const;
+type TLocaleKey = keyof typeof LOCALES;
+
+let currentLocale: TLocaleKey = 'zh';
+
+// `satisfies` lets the literal stay structurally typed (Record<string,
+// unknown>-like for the form-driven mutation below) while still failing
+// to compile if a key or value drifts from IMuyaOptions.
+const INITIAL_OPTIONS = {
+    // Markdown extensions
+    frontMatter: true,
     footnote: true,
+    math: true,
+    superSubScript: true,
+    isGitlabCompatibilityEnabled: true,
+    // Display
     codeBlockLineNumbers: true,
-});
+    focusMode: false,
+    spellcheckEnabled: false,
+    disableHtml: false,
+    // Editing behavior
+    autoPairBracket: true,
+    autoPairMarkdownSyntax: true,
+    autoPairQuote: true,
+    autoCheck: false,
+    autoMoveCheckedToEnd: false,
+    // Misc
+    preferLooseListItem: true,
+    hideQuickInsertHint: false,
+    hideLinkPopup: false,
+    trimUnnecessaryCodeBlockEmptyLines: false,
+    // Radios
+    bulletListMarker: '-',
+    orderListDelimiter: '.',
+    frontmatterType: '-',
+    // Selects
+    mermaidTheme: 'default',
+    vegaTheme: 'latimes',
+    // Numbers
+    fontSize: 16,
+    lineHeight: 1.6,
+    tabSize: 4,
+    listIndentation: 1,
+} satisfies Partial<IMuyaOptions>;
 
-muya.locale(zh);
+const currentOptions: Record<string, unknown> = { ...INITIAL_OPTIONS };
 
-muya.init();
+// ---------- Editor lifecycle ----------
 
-// Expose for in-browser debugging during PR-8 manual testing.
+function createEditor(container: HTMLElement, markdown: string): Muya {
+    const m = new Muya(container, { markdown, ...currentOptions } as Partial<IMuyaOptions>);
+    m.locale(LOCALES[currentLocale]);
+    m.init();
+    return m;
+}
+
+function bindEditorEvents(m: Muya) {
+    m.on('json-change', () => {
+        // eslint-disable-next-line no-console -- demo log for manual verification
+        console.log('[muya] TOC:', m.getTOC());
+    });
+    m.on('focus', () => {
+        // eslint-disable-next-line no-console -- demo log
+        console.log('[muya] focus');
+    });
+    m.on('blur', () => {
+        // eslint-disable-next-line no-console -- demo log
+        console.log('[muya] blur');
+    });
+}
+
+function freshEditorContainer(): HTMLElement {
+    const fresh = document.createElement('div');
+    fresh.id = 'editor';
+    document.querySelector('.editor-container')!.appendChild(fresh);
+    return fresh;
+}
+
+let muya = createEditor(document.querySelector('#editor')!, DEFAULT_MARKDOWN);
+bindEditorEvents(muya);
 window.muya = muya;
 
-// Language switcher
-const languageSelect: HTMLSelectElement = document.querySelector('#language-select')!;
-languageSelect.addEventListener('change', (event) => {
-    const lang = (event.target as HTMLSelectElement).value;
-    switch (lang) {
-        case 'en':
-            muya.locale(en);
-            break;
-        case 'ja':
-            muya.locale(ja);
-            break;
-        case 'zh':
-            muya.locale(zh);
-            break;
+function rebuildEditor() {
+    const md = muya.getMarkdown();
+    muya.destroy();
+    const next = createEditor(freshEditorContainer(), md);
+    bindEditorEvents(next);
+    muya = next;
+    window.muya = muya;
+}
+
+// ---------- Sidebar wiring ----------
+
+const $ = <T extends Element = HTMLElement>(sel: string) => document.querySelector<T>(sel)!;
+
+function wireLocale() {
+    const sel = $<HTMLSelectElement>('#language-select');
+    sel.value = currentLocale;
+    sel.addEventListener('change', (ev) => {
+        const v = (ev.target as HTMLSelectElement).value as TLocaleKey;
+        currentLocale = v;
+        muya.locale(LOCALES[v]);
+    });
+}
+
+function wireHistorySelection() {
+    $<HTMLButtonElement>('#undo').addEventListener('click', () => muya.undo());
+    $<HTMLButtonElement>('#redo').addEventListener('click', () => muya.redo());
+    $<HTMLButtonElement>('#select-all').addEventListener('click', () => muya.selectAll());
+    $<HTMLButtonElement>('#focus').addEventListener('click', () => muya.focus());
+}
+
+function wireFindReplace() {
+    $<HTMLInputElement>('#search').addEventListener('input', (ev) => {
+        muya.search((ev.target as HTMLInputElement).value, { isRegexp: true });
+    });
+    $<HTMLButtonElement>('#previous').addEventListener('click', () => muya.find('previous'));
+    $<HTMLButtonElement>('#next').addEventListener('click', () => muya.find('next'));
+    const replaceInput = $<HTMLInputElement>('#replace');
+    $<HTMLButtonElement>('#single').addEventListener('click', () => {
+        muya.replace(replaceInput.value, { isSingle: true, isRegexp: true });
+    });
+    $<HTMLButtonElement>('#all').addEventListener('click', () => {
+        muya.replace(replaceInput.value, { isSingle: false, isRegexp: false });
+    });
+}
+
+const MINIMAL_CONTENT: TState[] = [{ name: 'paragraph', text: 'foo bar' } as TState];
+
+function wireContent() {
+    $<HTMLButtonElement>('#set-content').addEventListener('click', () => {
+        muya.setContent(MINIMAL_CONTENT);
+    });
+    $<HTMLButtonElement>('#reset-demo').addEventListener('click', () => {
+        muya.setContent(DEFAULT_MARKDOWN, true);
+    });
+    $<HTMLButtonElement>('#clear-all').addEventListener('click', () => {
+        muya.setContent('');
+    });
+}
+
+function dump(text: string) {
+    $<HTMLTextAreaElement>('#debug-out').value = text;
+    // eslint-disable-next-line no-console -- demo: also echo to devtools
+    console.log(text);
+}
+
+function wireDebug() {
+    $<HTMLButtonElement>('#show-md').addEventListener('click', () => dump(muya.getMarkdown()));
+    $<HTMLButtonElement>('#show-state').addEventListener('click', () => {
+        dump(JSON.stringify(muya.getState(), null, 2));
+    });
+    $<HTMLButtonElement>('#show-toc').addEventListener('click', () => {
+        dump(JSON.stringify(muya.getTOC(), null, 2));
+    });
+    $<HTMLButtonElement>('#export-html').addEventListener('click', async () => {
+        const html = await new MarkdownToHtml(muya.getMarkdown()).generate();
+        dump(html);
+        // Use a Blob URL + noopener,noreferrer so the new tab cannot reach
+        // back into this page via window.opener (reverse-tabnabbing) and
+        // so the HTML is fetched as a real document instead of injected
+        // via document.write into a same-origin opener-linked window.
+        const blob = new Blob([html], { type: 'text/html' });
+        const url = URL.createObjectURL(blob);
+        window.open(url, '_blank', 'noopener,noreferrer');
+        // Release the Blob once the new tab has had a chance to load it.
+        setTimeout(() => URL.revokeObjectURL(url), 60_000);
+    });
+}
+
+// ---------- Options form ----------
+
+const RADIO_KEYS = ['bulletListMarker', 'orderListDelimiter', 'frontmatterType'] as const;
+
+function syncOptionFormFromState() {
+    document.querySelectorAll<HTMLInputElement | HTMLSelectElement>('[data-opt]').forEach((el) => {
+        const key = (el as HTMLElement).dataset.opt!;
+        const val = currentOptions[key];
+        if (el instanceof HTMLInputElement && el.type === 'checkbox')
+            el.checked = Boolean(val);
+        else
+            el.value = String(val ?? '');
+    });
+    for (const key of RADIO_KEYS) {
+        const wanted = String(currentOptions[key]);
+        document
+            .querySelectorAll<HTMLInputElement>(`input[name="opt-${key}"]`)
+            .forEach((el) => {
+                el.checked = el.value === wanted;
+            });
     }
-});
+}
 
-undoBtn.addEventListener('click', () => {
-    muya.undo();
-});
+function readOptionFromEvent(target: EventTarget | null) {
+    if (!(target instanceof HTMLInputElement || target instanceof HTMLSelectElement))
+        return;
+    const dataKey = (target as HTMLElement).dataset.opt;
+    if (dataKey) {
+        if (target instanceof HTMLInputElement && target.type === 'checkbox') {
+            currentOptions[dataKey] = target.checked;
+        }
+        else if (target instanceof HTMLInputElement && target.type === 'number') {
+            const num = Number.parseFloat(target.value);
+            if (!Number.isNaN(num))
+                currentOptions[dataKey] = num;
+        }
+        else { currentOptions[dataKey] = target.value; }
+        return;
+    }
+    if (target instanceof HTMLInputElement && target.type === 'radio' && target.checked) {
+        const radioKey = target.name.replace(/^opt-/, '');
+        currentOptions[radioKey] = target.value;
+    }
+}
 
-redoBtn.addEventListener('click', () => {
-    muya.redo();
-});
+function wireOptions() {
+    syncOptionFormFromState();
+    const form = $<HTMLFormElement>('#options-form');
+    form.addEventListener('change', ev => readOptionFromEvent(ev.target));
+    form.addEventListener('input', ev => readOptionFromEvent(ev.target));
+    $<HTMLButtonElement>('#apply-options').addEventListener('click', rebuildEditor);
+}
 
-searchInput.addEventListener('input', (event) => {
-    const value = (event.target as HTMLInputElement).value;
+// ---------- Boot ----------
 
-    muya.search(value, { isRegexp: true });
-});
-
-previousBtn.addEventListener('click', () => {
-    muya.find('previous');
-});
-
-nextBtn.addEventListener('click', () => {
-    muya.find('next');
-});
-
-singleBtn.addEventListener('click', () => {
-    muya.replace(replaceInput.value, { isSingle: true, isRegexp: true });
-});
-
-allBtn.addEventListener('click', () => {
-    muya.replace(replaceInput.value, { isSingle: false, isRegexp: false });
-});
-
-selectAllBtn.addEventListener('click', () => {
-    muya.selectAll();
-});
-
-const content = [
-    {
-        name: 'paragraph',
-        text: 'foo bar',
-    },
-];
-
-setContentBtn.addEventListener('click', () => {
-    muya.setContent(content as TState[]);
-});
-
-muya.on('json-change', (_changes) => {
-    // console.log(JSON.stringify(muya.getState(), null, 2))
-    // console.log(muya.getMarkdown())
-    // console.log(JSON.stringify(_changes, null, 2));
-    // eslint-disable-next-line no-console -- demo log for manual TOC verification (PR-15)
-    console.log('[muya] TOC:', muya.getTOC());
-});
-
-// eslint-disable-next-line no-console -- demo log for manual TOC verification (PR-15)
-console.log('[muya] TOC (initial):', muya.getTOC());
-
-muya.on('focus', () => {
-    // eslint-disable-next-line no-console -- demo log for manual focus verification
-    console.log('[muya] focus');
-});
-
-muya.on('blur', () => {
-    // eslint-disable-next-line no-console -- demo log for manual focus verification
-    console.log('[muya] blur');
-});
-
-// muya.on('selection-change', changes => {
-//   const { anchor, focus, path } = changes
-//   console.log(JSON.stringify([anchor.offset, focus.offset, path]))
-// })
-
-const md2Html = new MarkdownToHtml(DEFAULT_MARKDOWN);
-md2Html.generate().then((_html) => {
-    // const container = document.createElement("div");
-    // container.innerHTML = _html;
-    // document.body.appendChild(container);
-    // console.log(_html);
-});
+wireLocale();
+wireHistorySelection();
+wireFindReplace();
+wireContent();
+wireDebug();
+wireOptions();

--- a/examples/src/main.ts
+++ b/examples/src/main.ts
@@ -168,6 +168,12 @@ function rebuildEditor() {
 
 const $ = <T extends Element = HTMLElement>(sel: string) => document.querySelector<T>(sel)!;
 
+function wireSidebarToggle() {
+    $<HTMLButtonElement>('#sidebar-toggle').addEventListener('click', () => {
+        document.body.classList.toggle('sidebar-collapsed');
+    });
+}
+
 function wireLocale() {
     const sel = $<HTMLSelectElement>('#language-select');
     sel.value = currentLocale;
@@ -298,6 +304,7 @@ function wireOptions() {
 
 // ---------- Boot ----------
 
+wireSidebarToggle();
 wireLocale();
 wireHistorySelection();
 wireFindReplace();

--- a/examples/src/style.css
+++ b/examples/src/style.css
@@ -1,92 +1,237 @@
-@supports(-moz-appearance:none) {
-  /* CSS code */
-  html {
-    position: fixed;
-  }
+@supports (-moz-appearance: none) {
+    html {
+        position: fixed;
+    }
 }
 
 html,
 body {
-  margin: 0;
-  padding: 0;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
-.tools {
-  position: fixed;
-  top: 0;
-  z-index: 100000;
+/* ---------- Sidebar ---------- */
 
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 100vw;
-  height: 40px;
+.sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 100000;
 
-  background-color: #fff;
+    box-sizing: border-box;
+    width: 340px;
+    height: 100vh;
+    padding: 12px;
+    overflow-y: auto;
+
+    font-size: 13px;
+    line-height: 1.5;
+
+    background-color: #fafafa;
+    border-right: 1px solid #e5e5e5;
 }
 
-button {
-  box-sizing: border-box;
-  height: 26px;
-  margin-right: 10px;
-  padding: 0 5px;
+.sidebar-brand {
+    margin: 0 0 12px;
+    padding: 6px 4px;
+
+    font-weight: 700;
+
+    font-size: 15px;
+
+    border-bottom: 1px solid #e5e5e5;
 }
 
-input {
-  box-sizing: border-box;
-  width: 150px;
-  height: 26px;
-  margin-right: 10px;
-  padding: 0 5px;
+.sidebar details {
+    margin-bottom: 8px;
+    padding: 0 8px 8px;
 
-  border: 1px solid #eee;
-  border-radius: 4px;
-  outline: none;
+    background-color: #fff;
+    border: 1px solid #ececec;
+    border-radius: 4px;
 }
 
-.language-selector {
-  display: flex;
-  gap: 8px;
-  align-items: center;
-  margin-right: 10px;
+.sidebar summary {
+    margin: 0 -8px;
+    padding: 6px 8px;
+
+    font-weight: 600;
+
+    cursor: pointer;
+
+    user-select: none;
 }
 
-.language-selector label {
-  color: #333;
-  font-size: 14px;
-  white-space: nowrap;
+.sidebar details > *:not(summary) {
+    margin: 6px 0;
 }
 
-.language-selector select {
-  height: 26px;
-  padding: 0 8px;
-
-  font-size: 14px;
-
-  background-color: #fff;
-  border: 1px solid #eee;
-  border-radius: 4px;
-  outline: none;
-  cursor: pointer;
+.sidebar-hint {
+    color: #999;
+    font-weight: 400;
 }
+
+.sidebar button,
+.sidebar input[type="text"],
+.sidebar input[type="number"],
+.sidebar select,
+.sidebar textarea {
+    box-sizing: border-box;
+    width: 100%;
+    margin: 3px 0;
+    padding: 4px 6px;
+
+    font: inherit;
+
+    background-color: #fff;
+    border: 1px solid #d0d0d0;
+    border-radius: 3px;
+    outline: none;
+}
+
+.sidebar button {
+    background-color: #f5f5f5;
+    cursor: pointer;
+}
+
+.sidebar-row {
+    display: flex;
+    gap: 6px;
+}
+
+.sidebar-row button {
+    flex: 1;
+    margin: 3px 0;
+}
+
+.sidebar button:hover {
+    background-color: #ececec;
+}
+
+.sidebar fieldset {
+    margin: 6px 8px;
+    padding: 6px 8px;
+
+    border: 1px solid #ececec;
+    border-radius: 3px;
+}
+
+.sidebar fieldset legend {
+    padding: 0 4px;
+
+    color: #555;
+    font-weight: 600;
+    font-size: 12px;
+}
+
+.sidebar fieldset label {
+    display: block;
+
+    padding: 1px 0;
+
+    cursor: pointer;
+}
+
+.sidebar fieldset input[type="checkbox"],
+.sidebar fieldset input[type="radio"] {
+    margin-right: 6px;
+
+    vertical-align: middle;
+}
+
+.sidebar-field {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+.sidebar-field > span {
+    flex: 1;
+
+    color: #555;
+}
+
+.sidebar-field > input,
+.sidebar-field > select {
+    flex: 1;
+    width: auto;
+}
+
+.sidebar #debug-out {
+    min-height: 120px;
+
+    font-size: 11px;
+
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    line-height: 1.4;
+    white-space: pre;
+
+    resize: vertical;
+}
+
+.sidebar-hints {
+    margin: 6px 8px;
+    padding-left: 18px;
+
+    color: #444;
+    line-height: 1.5;
+}
+
+.sidebar-hints code {
+    padding: 0 4px;
+
+    font-size: 12px;
+
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    background-color: #f0f0f0;
+    border-radius: 3px;
+}
+
+/* ---------- Editor area ---------- */
 
 .editor-container {
-  position: absolute;
-  top: 0;
-  left: 0;
+    position: absolute;
+    top: 0;
+    right: 0;
+    left: 340px;
 
-  box-sizing: border-box;
-  width: 100vw;
-  height: 100vh;
-  padding-top: 80px;
-  overflow: auto;
+    box-sizing: border-box;
+    height: 100vh;
+    padding: 24px 32px;
+    overflow: auto;
 }
 
 #editor {
-  box-sizing: border-box;
-  width: 100%;
+    box-sizing: border-box;
+    width: 100%;
 
-  font-size: 16px;
+    font-size: 16px;
 
-  outline: none;
+    outline: none;
+}
+
+/* ---------- Responsive fallback ---------- */
+
+@media (max-width: 720px) {
+    .sidebar {
+        position: static;
+
+        width: 100%;
+        height: auto;
+        max-height: 50vh;
+
+        border-right: none;
+        border-bottom: 1px solid #e5e5e5;
+    }
+
+    .editor-container {
+        position: static;
+        left: 0;
+
+        height: auto;
+    }
 }

--- a/examples/src/style.css
+++ b/examples/src/style.css
@@ -13,6 +13,35 @@ body {
     font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
 
+/* ---------- Sidebar toggle (always visible) ---------- */
+
+.sidebar-toggle {
+    position: fixed;
+    top: 8px;
+    left: 300px;
+    z-index: 100001;
+
+    box-sizing: border-box;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+
+    font-size: 18px;
+    line-height: 30px;
+    text-align: center;
+
+    background-color: #fff;
+    border: 1px solid #d0d0d0;
+    border-radius: 4px;
+    cursor: pointer;
+
+    transition: left 0.2s ease;
+}
+
+.sidebar-toggle:hover {
+    background-color: #f0f0f0;
+}
+
 /* ---------- Sidebar ---------- */
 
 .sidebar {
@@ -32,6 +61,16 @@ body {
 
     background-color: #fafafa;
     border-right: 1px solid #e5e5e5;
+
+    transition: transform 0.2s ease;
+}
+
+body.sidebar-collapsed .sidebar {
+    transform: translateX(-100%);
+}
+
+body.sidebar-collapsed .sidebar-toggle {
+    left: 8px;
 }
 
 .sidebar-brand {
@@ -203,6 +242,12 @@ body {
     height: 100vh;
     padding: 24px 32px;
     overflow: auto;
+
+    transition: left 0.2s ease;
+}
+
+body.sidebar-collapsed .editor-container {
+    left: 0;
 }
 
 #editor {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -6,6 +6,7 @@ export { MarkdownToHtml } from './state/markdownToHtml';
 export { renderToStaticHTML } from './state/renderToStaticHTML';
 export type { IRenderToStaticHTMLOptions } from './state/renderToStaticHTML';
 export type { TState } from './state/types';
+export type { IMuyaOptions } from './types';
 
 export { CodeBlockLanguageSelector } from './ui/codeBlockLanguageSelector';
 // Export ui tools.


### PR DESCRIPTION
## Summary

- Rewrite `examples/src/data.ts` `DEFAULT_MARKDOWN` as 16 ATX chapters covering all 26 registered blocks and 20+ inline formats; `muya.getTOC()` now doubles as a feature-coverage checklist.
- Convert the fixed top toolbar in `examples/index.html` to a 280px left sidebar built with native `<details>` (zero new deps), grouped into seven collapsible sections: Locale, History & Selection, Find & Replace, Content, Export & Debug, Muya Options, UI plugin hints.
- Expose every `IMuyaOptions` field (18 checkboxes, 3 radio groups, 2 selects, 4 number inputs). "Apply settings & reload" performs `getMarkdown → destroy → new Muya(options) → init` because most options are consumed only at construction time (e.g. `footnote`, `math`, `frontMatter`, `codeBlockLineNumbers`, `mermaidTheme`, `bulletListMarker`).
- Add Reset to demo / Clear all / Focus buttons and a debug textarea for Show MD / Show State / Show TOC / Export HTML (the latter also pops a preview window via `MarkdownToHtml.generate`).
- Fix `.lintstagedrc`: scope CSS lint to `*.css` only — the previous `*.{html,css}` matcher routed staged HTML files into stylelint, which fails to parse them as CSS. Editing example HTML no longer blocks commits.

## Test plan

- [x] `pnpm dev` boots Vite cleanly and the playground loads
- [x] All 16 ATX chapters render correctly; **Show TOC** lists each one
- [x] Toggle `math` off → **Apply**: `$$ \int … $$` block reverts to plain text; toggle on → restored
- [x] Same drill for `footnote`, `codeBlockLineNumbers`, `frontMatter`, `superSubScript`, `disableHtml`
- [x] Switch `bulletListMarker` to `*` + **Apply**: **Show MD** serializes bullet lists with `*`
- [x] Switch `mermaidTheme` to `dark` + **Apply**: mermaid diagrams re-render dark
- [x] **Clear all** empties the editor; **Reset to demo** restores the full document
- [x] **Export HTML** dumps HTML into the textarea and pops a new window with the rendered preview
- [x] Sidebar collapses to a top stack at viewport width ≤ 720px
- [x] All UI plugin hints fire as described (paragraph menu, format toolbar, quick insert `/`, emoji `:`, table tools, image tools, code language picker, link tools, footnote tool, preview toolbar)

🤖 Generated with [Claude Code](https://claude.com/claude-code)