### PR TITLE
docs(readme): announce migration to marktext/marktext repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 <p align="center"><img src="./docs/logo.jpg" alt="muya" height="150"></p>
 
+> [!IMPORTANT]
+> **This repository has been migrated into [marktext/marktext](https://github.com/marktext/marktext).**
+>
+> Muya now lives inside the MarkText monorepo. To use Muya or contribute code, please head over to the [marktext/marktext](https://github.com/marktext/marktext) repository. This repo will no longer receive updates. Thank you!
+
 <p align="center"><b>Muya</b> — a standalone Markdown editor for the web, extracted from <a href="https://github.com/marktext/marktext">MarkText</a>.</p>
 
 > Status: Muya is still under active development. APIs may change between minor versions and it is not yet recommended for production use.


### PR DESCRIPTION
## Summary

- Adds a top-of-README notice that this repository has been migrated into [marktext/marktext](https://github.com/marktext/marktext).
- Directs users and contributors to head over to the MarkText monorepo for using Muya or contributing code.

## Test plan

- [ ] README renders correctly on GitHub with the `> [!IMPORTANT]` callout.
- [ ] Links to `marktext/marktext` resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)